### PR TITLE
fix: avoid picking variables names as decorators

### DIFF
--- a/src/parse/removeDecorators.ts
+++ b/src/parse/removeDecorators.ts
@@ -11,7 +11,7 @@ import backtrace from '../error/backtrace.js';
 import logger from '../utils/logger.js';
 
 // regex: matches all cases of 'known' unless they are directly preceded by 'un'
-const decorators = [/secret/g, /unknown/g, /\w*(?<!un)known/g, /reinitialisable/g];
+const decorators = [/(?<![\w])known(?![\w])/g, /(?<![\w])unknown(?![\w])/g, /(?<![\w])secret(?![\w])/g, /(?<![\w])reinitialisable(?![\w])/g];
 
 function tidy(_line: string): string {
   let line = _line;

--- a/src/parse/removeDecorators.ts
+++ b/src/parse/removeDecorators.ts
@@ -10,7 +10,8 @@ import { ToRedecorate } from './redecorate.js'
 import backtrace from '../error/backtrace.js';
 import logger from '../utils/logger.js';
 
-// regex: matches all cases of 'known' unless they are directly preceded by 'un'
+// regex: matches decorators when standalone words
+// eg: for {unknown knownknown known1 123lknown known secretvalue} finds only 1 match for decorator 'known'
 const decorators = [/(?<![\w])known(?![\w])/g, /(?<![\w])unknown(?![\w])/g, /(?<![\w])secret(?![\w])/g, /(?<![\w])reinitialisable(?![\w])/g];
 
 function tidy(_line: string): string {


### PR DESCRIPTION
This fixes #66 .
Now , regex are picked up as decorators only if the whole string matches . Attaching a screenshot of the expected matches output.

<img width="1155" alt="Screenshot 2022-03-03 at 9 58 09 AM" src="https://user-images.githubusercontent.com/89987481/156496282-5f344199-4cf0-4e0b-836a-6f8910f840c0.png">
 
To test , rename variables and/or methods in `/test` zol files to substring of decorators like `KnownID` or `secretvalue1`