### PR TITLE
Complete overloaded functions

### DIFF
--- a/src/boilerplate/contract/solidity/nodes/ContractBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/ContractBoilerplateGenerator.ts
@@ -71,7 +71,7 @@ class ContractBoilerplateGenerator {
       const fnDefBindings = scope.filterBindings(
         (b: any) => b.kind === 'FunctionDefinition' && b.name !== '',
       );
-      const functionNames = Object.values(fnDefBindings).map((b: any) => b.name);
+      const functionNames = Object.values(fnDefBindings).map((b: any) => b.path.getUniqueFunctionName());
 
       return {
         functionNames,

--- a/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
@@ -87,7 +87,7 @@ class FunctionBoilerplateGenerator {
       const params = path.getFunctionParameters();
       const publicParams = params?.filter((p: any) => !p.isSecret).map((p: any) => p.name);
 
-      const functionName = path.node.name;
+      const functionName = path.getUniqueFunctionName();
 
       const indicators = this.customFunction.getIndicators.bind(this)();
 

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -55,41 +55,13 @@ const visitor = {
             indicators,
           }),
         );
-// before creating a function node we check for functions with same name
-  const prevsiblingsNames = path.getAllPrevSiblingNodes();
-  const nextsiblingsNames = path.getAllNextSiblingNodes();
-var index = 0
-let incIndex =0;
-var fnName = node.name;
-for (let i = 0; i < prevsiblingsNames.length; i++)
-   {
-        if (fnName === prevsiblingsNames[i].name)
-        index ++;
-        }
-if (index > 0) {
-  fnName = node.name+'_'+index;
-  do{
- incIndex = 1;
-  for (let i = 0; i < prevsiblingsNames.length; i++)
-     {
-          if (fnName === prevsiblingsNames[i].name)
-          {
-            index ++;
-            incIndex--;
-        }
 
-          }
-  for (let i = 0; i < nextsiblingsNames.length; i++)
-     {
-          if (fnName === nextsiblingsNames[i].name)
-          {index ++; incIndex--;}
-      }
-  fnName = node.name+'_'+index;
-    }while(incIndex === 0)
-      fnName = node.name+'_'+index;
-}
+        // before creating a function node we check for functions with same name
+        const fnName = path.getUniqueFunctionName();
+        node.fileName = fnName;
 
-// After getting an appropriate Name , we build the node
+
+        // After getting an appropriate Name , we build the node
         const newNode = buildNode('File', {
          fileName: fnName,
           fileId: node.id,

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -153,7 +153,7 @@ export default {
       const { node, parent } = path;
       const isConstructor = node.kind === 'constructor';
       const newNode = buildNode('FunctionDefinition', {
-        name: node.name,
+        name: node.fileName || path.getUniqueFunctionName(),
         id: node.id,
         visibility: isConstructor ? '' : 'external',
         isConstructor,

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -137,41 +137,7 @@ export default {
 
       if (scope.modifiesSecretState()) {
         const contractName = `${parent.name}Shield`;
-        const siblingsNames = path.getAllPrevSiblingNodes();
-        // before creating a function node we check for functions with same name
-          const prevsiblingsNames = path.getAllPrevSiblingNodes();
-          const nextsiblingsNames = path.getAllNextSiblingNodes();
-        var index = 0
-        let incIndex =0;
-        var fnName = node.name;
-        for (let i = 0; i < prevsiblingsNames.length; i++)
-           {
-                if (fnName === prevsiblingsNames[i].name)
-                index ++;
-                }
-        if (index > 0) {
-          fnName = node.name+'_'+index;
-          do{
-         incIndex = 1;
-          for (let i = 0; i < prevsiblingsNames.length; i++)
-             {
-                  if (fnName === prevsiblingsNames[i].name)
-                  {
-                    index ++;
-                    incIndex--;
-                }
-
-                  }
-          for (let i = 0; i < nextsiblingsNames.length; i++)
-             {
-                  if (fnName === nextsiblingsNames[i].name)
-                  {index ++; incIndex--;}
-              }
-          fnName = node.name+'_'+index;
-            }while(incIndex === 0)
-              fnName = node.name+'_'+index;
-        }
-
+        const fnName = path.getUniqueFunctionName();
         node.fileName = fnName;
 
         // After getting an appropriate Name , we build the node

--- a/src/traverse/Indicator.ts
+++ b/src/traverse/Indicator.ts
@@ -88,7 +88,10 @@ export class FunctionDefinitionIndicator extends ContractDefinitionIndicator {
 
   updateIncrementation(path: NodePath, state: any) {
     this.parentIndicator.updateIncrementation(path, state);
-    if (!path.isIncremented || state.incrementedIdentifier.isKnown) {
+    if (
+      !path.isIncremented ||
+      state.incrementedIdentifier.isKnown || path.scope.getReferencedBinding(state.incrementedIdentifier).isKnown
+    ) {
       // a reinitialised state does require new commitments
       this.newCommitmentsRequired = true;
       this.initialisationRequired = true;
@@ -455,7 +458,10 @@ export class StateVariableIndicator extends FunctionDefinitionIndicator {
 
   updateIncrementation(path: NodePath, state: any) {
     this.parentIndicator.updateIncrementation(path, state);
-    if (!path.isIncremented || state.incrementedIdentifier.isKnown) {
+    if (
+      !path.isIncremented ||
+      state.incrementedIdentifier.isKnown || path.scope.getReferencedBinding(state.incrementedIdentifier).isKnown
+    ) {
       this.isWhole = true;
       const reason = { src: state.incrementedIdentifier.src, 0: `Overwritten` };
       this.isWholeReason ??= [];
@@ -530,6 +536,7 @@ export class StateVariableIndicator extends FunctionDefinitionIndicator {
 
   addNullifyingPath(path: NodePath) {
     this.isNullified = true;
+    this.parentIndicator.nullifiersRequired = true;
     this.oldCommitmentAccessRequired = true;
     ++this.nullificationCount;
     this.nullifyingPaths.push(path);
@@ -563,7 +570,6 @@ export class StateVariableIndicator extends FunctionDefinitionIndicator {
     }
     // error: conflicting unknown/whole state
     if (this.isUnknown && this.isWhole) {
-      console.log('err 3');
       throw new SyntaxUsageError(
         `Can't mark a whole state as 'unknown'`,
         this.node,

--- a/src/traverse/NodePath.ts
+++ b/src/traverse/NodePath.ts
@@ -1005,6 +1005,43 @@ export default class NodePath {
     }
   }
 
+  getUniqueFunctionName() {
+    if (this.node.fileName) return this.node.fileName;
+    // before creating a function node we check for functions with same name
+    const prevSiblings = this.getAllPrevSiblingNodes();
+    const nextSiblings = this.getAllNextSiblingNodes();
+    let index = 0
+    let incIndex = 0;
+    let fnName = this.node.name;
+
+    prevSiblings.forEach((sibling: any) => {
+      if (fnName === sibling.name) index ++;
+    });
+
+    if (index === 0) return fnName;
+
+    fnName = this.node.name + '_' + index;
+
+    while (incIndex === 0) {
+      incIndex = 1;
+      prevSiblings.forEach((sibling: any) => {
+        if (fnName === sibling.name) {
+          index ++;
+          incIndex --;
+        }
+      });
+      nextSiblings.forEach((sibling: any) => {
+        if (fnName === sibling.name) {
+          index ++;
+          incIndex --;
+        }
+      });
+      fnName = this.node.name + '_' + index;
+    }
+    this.node.fileName = fnName;
+    return fnName;
+  }
+
   // SCOPE
 
   // checks whether this path's nodeType is one which signals the beginning of a new scope

--- a/src/traverse/NodePath.ts
+++ b/src/traverse/NodePath.ts
@@ -33,6 +33,7 @@ import {
   traversePathsFast
 } from './traverse.js';
 import logger from '../utils/logger.js';
+import backtrace from '../error/backtrace.js';
 import { pathCache } from './cache.js';
 import { Scope } from './Scope.js';
 import { Binding } from './Binding.js';
@@ -1038,6 +1039,8 @@ export default class NodePath {
       });
       fnName = this.node.name + '_' + index;
     }
+    logger.info(`ALERT: Your overloaded function ${this.node.name} has been renamed to ${fnName} to prevent overwrites!`)
+    backtrace.getSourceCode(this.node.src);
     this.node.fileName = fnName;
     return fnName;
   }


### PR DESCRIPTION
Closes #81 and addresses all points there (copying for visibility). Now fixed:

- The output shield contract contains an enum of function names with duplicates (meaning some vks are never accessed)
- The shield also follows the original .zol in keeping functions of the same name, but in the shield they may have the same signature because secret params are not included
- Unsure if orchestration files are setup to call the correct function in the shield contract and generate proofs based on the correct pk
- Common files (e.g. zkp-setup) may not collect all function names correctly

Additionally fixed an edge case bug where a whole (incremented but marked as known) state was not being marked as nullified when modified as part of an incrementation.

This PR can be tested by `zappify`ing and testing `Assign-Function.zol`