### PR TITLE
fix: generalise whole state after editing statements

### DIFF
--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -419,11 +419,11 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
       lines[0] = preimageBoilerPlate(node);
       for ([stateName, stateNode] of Object.entries(node.privateStates)) {
         if (stateNode.accessedOnly) {
+          // if the state is only accessed, we need to initalise it here before statements
           params.push(
             `\nconst ${stateName} = generalise(${stateName}_preimage.${stateName});`,
           );
-        } else if (stateNode.isWhole)
-          params.push(`\n${stateName} = generalise(${stateName});`);
+        }
       }
       return {
         statements: [`${params.join('\n')}`, lines[0].join('\n')],

--- a/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
@@ -127,6 +127,8 @@ export default function codeGenerator(node: any, options: any = {}): any {
           return `parseInt(${node.name}.integer, 10)`;
         case 'address':
           return `${node.name}.integer`;
+        case 'generalNumber':
+          return `generalise(${node.name})`;
       }
 
     case 'Folder':

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -398,6 +398,17 @@ export default {
             });
           }
           if (stateVarIndicator.isModified) {
+            if (stateVarIndicator.isWhole) {
+              // if we have a modified whole state, we must generalise it before postStatements
+              node._newASTPointer.body.statements.push(
+                buildNode('Assignment', {
+                    leftHandSide: buildNode('Identifier', { name }),
+                    operator: '=',
+                    rightHandSide: buildNode('Identifier', { name, subType: 'generalNumber' })
+                  }
+                )
+              );
+            }
             newNodes.generateProofNode.privateStates[
               name
             ] = buildPrivateStateNode('GenerateProof', {
@@ -489,7 +500,7 @@ export default {
             accessedOnly: true,
           });
         }
-          const newFunctionDefinitionNode = node._newASTPointer;
+        const newFunctionDefinitionNode = node._newASTPointer;
 
         // this adds other values we need in the circuit
         for (const param of node._newASTPointer.parameters.parameters) {


### PR DESCRIPTION
Small fix to code changes which fixes a previous bodge written by me.

- Problem: after reading the preimage, we would modify the state then convert it into a `GeneralNumber` so we can access it as a `.integer`, `.hex` as needed. Now reading the preimage is correctly a pre-statement, this occurs before any modifications, so we were generalising a state which did not yet exist.
- Fix: move the generalise line to the end of statements, so it comes after any reading and before any accessing