### PR TITLE
modifiers for permissioned function calls

### DIFF
--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -29,7 +29,10 @@ function codeGenerator(node: any) {
       return `${CircuitBP.uniqueify(node.imports.flatMap(codeGenerator)).join('\n')}`;
 
     case 'FunctionDefinition': {
-      const modifierBody = ` assert(${codeGenerator(node.modifiers)})`;
+      let modifierBody: any = '';
+      if(node.modifiers.operator) {
+      modifierBody = ` assert(${codeGenerator(node.modifiers)})`;
+      }
       const functionSignature = `def main(\\\n\t${codeGenerator(node.parameters)}\\\n) -> bool:`;
       const body = codeGenerator(node.body);
       return `${functionSignature}

--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -29,14 +29,16 @@ function codeGenerator(node: any) {
       return `${CircuitBP.uniqueify(node.imports.flatMap(codeGenerator)).join('\n')}`;
 
     case 'FunctionDefinition': {
-      let modifierBody: any = '';
-      if(node.modifiers.operator) {
-      modifierBody = ` assert(${codeGenerator(node.modifiers)})`;
+      let modifierBody: any = [];
+        for( var i=0; i< node.modifiers.length ; i++) {
+          if(node.modifiers[i].operator) {
+      modifierBody[i] = `assert(${codeGenerator(node.modifiers[i])}) \n\t\t\t\t\t\t\t`;
+        }
       }
       const functionSignature = `def main(\\\n\t${codeGenerator(node.parameters)}\\\n) -> bool:`;
       const body = codeGenerator(node.body);
       return `${functionSignature}
-        ${modifierBody}
+              ${modifierBody.toString().replace(',' , '')}
         ${body}
 
         return true

--- a/src/codeGenerators/contract/solidity/toContract.ts
+++ b/src/codeGenerators/contract/solidity/toContract.ts
@@ -77,6 +77,23 @@ function codeGenerator(node: any) {
         }`;
     }
 
+    case 'ModifierDefinition': {
+      console.log('git' , node.body.statements);
+      // prettier-ignore
+      const modifierSignature = `${`modifier ${node.name}`
+      }(${codeGenerator(node.parameters)}) {`;
+      const body = codeGenerator(node.body);
+      return `
+        ${modifierSignature}
+
+          ${body}
+
+        }`;
+    }
+
+    case 'PlaceholderStatement':
+      return '\t\t\t\t _;';
+
     case 'ParameterList':
       return node.parameters.flatMap(codeGenerator).filter(Boolean).join(', ');
 
@@ -111,9 +128,9 @@ function codeGenerator(node: any) {
     }
 
     case 'Block': {
-      const preStatements: string = node.preStatements.flatMap(codeGenerator);
-      const statements: string = node.statements.flatMap(codeGenerator);
-      const postStatements: string = node.postStatements.flatMap(codeGenerator);
+      const preStatements = node.preStatements?node.preStatements.flatMap(codeGenerator): '';
+      const statements = node.statements?node.statements.flatMap(codeGenerator): '';
+      const postStatements = node.postStatements?node.postStatements.flatMap(codeGenerator): '';
       return [...preStatements, ...statements, ...postStatements].join('\n');
     }
     case 'ExpressionStatement':

--- a/src/codeGenerators/orchestration/files/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/files/toOrchestration.ts
@@ -259,7 +259,7 @@ export default function fileGenerator(node: any) {
   switch (node.nodeType) {
     case 'Folder':
       return OrchestrationBP.uniqueify(node.files
-        .filter((x: any) => x.nodeType !== 'NonSecretFunction')
+        .filter((x: any) => x.nodeType !== 'NonSecretFunction' && x.nodeType !== 'ModifierDefinition')
         .flatMap(fileGenerator));
 
 

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -128,14 +128,18 @@ const visitor = {
     enter(path: NodePath, state: any) {
 
       const { node, parent, scope } = path;
+      let modifierStatements = [];
       if(node.modifiers.length>0) {
         let modifiersLIst =  path.getAllPrevSiblingNodes().filter((x: any) => x.nodeType == 'ModifierDefinition');
-        for(var i =0; i<modifiersLIst.length; i++) {
-        if(node.modifiers[0].modifierName.name == modifiersLIst[i].name)
-        node.modifiers.statements = modifiersLIst[i].body.statements[0].expression.arguments;
+        for(var j=0; j< node.modifiers.length; j++) {
+          for(var i =0; i<modifiersLIst.length; i++) {
+            if(node.modifiers[j].modifierName.name == modifiersLIst[i].name)  {
+            modifierStatements.push(modifiersLIst[i].body.statements[0].expression.arguments[0]);
+            }
+          }
         }
       }
-      // Check the function for modifications to any stateVariables.
+            // Check the function for modifications to any stateVariables.
       // We'll need to create a new circuit file if we find a modification.
       // TODO: will we also need a new circuit file even if we're merely 'referring to' a secret state (because then a nullifier might be needed?)
       if (scope.modifiesSecretState()) {
@@ -146,7 +150,7 @@ const visitor = {
         newFunctionDefinitionNode = buildNode('FunctionDefinition', {
           name: 'main',
           body: node.body,
-          modifiers: node.modifiers.statements[0],
+          modifiers: modifierStatements,
         });
       }
       else {

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -220,11 +220,6 @@ export default {
     enter(path: NodePath, state: any) {
       const { node, parent } = path;
       const isConstructor = node.kind === 'constructor';
-      if(node.modifiers.length>0) {
-        let modifiersLIst =  path.getAllPrevSiblingNodes().filter((x: any) => x.nodeType == 'ModifierDefinition');
-       modifiersLIst[0].body.statements[0].containsSecret = true;
-       node.body.statements.unshift(modifiersLIst[0].body.statements[0]);
-        }
       const newNode = buildNode('FunctionDefinition', {
         name: node.fileName || path.getUniqueFunctionName(),
         id: node.id,

--- a/src/traverse/Binding.ts
+++ b/src/traverse/Binding.ts
@@ -29,6 +29,7 @@ export class Binding {
       case 'FunctionDefinition':
       case 'VariableDeclaration':
         return true;
+      case 'ModifierDefinition':  
       case 'IfStatement':  
       case 'ArrayTypeName':
       case 'Assignment':
@@ -51,6 +52,7 @@ export class Binding {
       case 'UnaryOperation':
       case 'UserDefinedTypeName':
       case 'VariableDeclarationStatement':
+      case 'PlaceholderStatement':
         return false;
       default:
         logger.error(`Hitherto unknown nodeType '${nodeType}'`);

--- a/src/traverse/Scope.ts
+++ b/src/traverse/Scope.ts
@@ -261,6 +261,7 @@ export class Scope {
       case 'FunctionCall':
       case 'ContractDefinition':
       case 'FunctionDefinition':
+      case 'ModifierDefinition':
       case 'ArrayTypeName':
       case 'Assignment':
       case 'Block':

--- a/src/types/solidity-types.ts
+++ b/src/types/solidity-types.ts
@@ -50,6 +50,7 @@ export function getVisitableKeys(nodeType: string): string[] {
     case 'Literal':
     case 'UserDefinedTypeName':
     case 'ImportDirective':
+    case 'ModifierDefinition':
       return [];
 
     // And again, if we haven't recognized the nodeType then we'll throw an
@@ -135,6 +136,22 @@ export function buildNode(nodeType: string, fields: any = {}): any {
         name,
         visibility,
         isConstructor,
+        body,
+        parameters,
+        // returnParameters,
+      };
+    }
+
+    case 'ModifierDefinition': {
+      const {
+        name,
+        body = buildNode('Block'),
+        parameters = buildNode('ParameterList'),
+        // returnParameters = buildNode('ParameterList'), // TODO
+      } = fields;
+      return {
+        nodeType,
+        name,
         body,
         parameters,
         // returnParameters,

--- a/src/types/zokrates-types.ts
+++ b/src/types/zokrates-types.ts
@@ -47,13 +47,15 @@ export function buildNode(nodeType: string, fields: any = {}): any {
       const {
         name,
         body = buildNode('Block'),
-        parameters = buildNode('ParameterList')
+        parameters = buildNode('ParameterList'),
+        modifiers = buildNode('BinaryOperation'),
       } = fields;
       return {
         nodeType,
         name,
         body,
         parameters,
+        modifiers,
         // Notice no return parameters. Although zokrates _can_ return parameters, we've chosen to transpile in such a way that all parameters are _input_ parameters to the circuit.
       };
     }

--- a/test/contracts/modifier.zol
+++ b/test/contracts/modifier.zol
@@ -13,7 +13,11 @@ contract Owner {
    require(msg.sender == admin);
     _;
     }
-  function alpha() private onlyOwner{
+   modifier onlyUser() {
+   require(msg.sender == adminstartor);
+    _;
+    }
+  function alpha() private onlyOwner onlyUser {
     a+=1;
     }
 }

--- a/test/contracts/modifier.zol
+++ b/test/contracts/modifier.zol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+contract Owner {
+  secret uint256 private a;
+  secret address private admin;
+  secret address private adminstartor;
+  constructor() {
+      admin = msg.sender;
+    }
+  modifier onlyOwner() {
+   require(msg.sender == admin);
+    _;
+    }
+  function alpha() private onlyOwner{
+    a+=1;
+    }
+}
+


### PR DESCRIPTION

Using modifiers is common way to restrict permissions access to a function. With this PR , starlight can support modifiers. 
In circuit construction , we traverse the AST of `functionDefinition` and  look for  `getAllPrevSiblingNodes()` of Type `ModifierDefinition` .  The `modifiers` parameter of `functionDefinition` node gives list of all modifiers.  In Zokrates , permission checks are done by `assert` operation.

For non secret interactions , we copy over the modifier code shield contract.
