### PR TITLE
Fix to automated tests

### DIFF
--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -793,12 +793,13 @@ const visitor = {
           return;
         }
       }
-      // if (node.expression.nodeType !== 'FunctionCall') {
+      if (node.expression.expression?.name !== 'require') {
         const newNode = buildNode(node.nodeType, {
           interactsWithSecret,
         });
         node._newASTPointer = newNode;
         parent._newASTPointer.push(newNode);
+      }
 
     },
 

--- a/test/test.js
+++ b/test/test.js
@@ -17,28 +17,19 @@ describe("AST testing", function () {
     it("zappifies each contract", function () {
       this.timeout(100000);
       files.forEach((file) => {
+        logger.info('zappifying', file);
         options.inputFilePath = './test/contracts/'+file;
         options.modifyAST = 'n';
-        options.inputFileName = path.parse(inputFilePath).name;
+        options.inputFileName = path.parse(options.inputFilePath).name;
         // commander converts 'zapp-name' to 'zappName'
-        options.zappName = inputFileName;
-        options.outputDirPath = `./temp-zapps/${zappName}`;
-        options.parseDirPath = `${outputDirPath}/parse`;
-        options.circuitsDirPath = `${outputDirPath}/circuits`;
-        options.contractsDirPath = `${outputDirPath}/contracts`;
-        options.orchestrationDirPath = `${outputDirPath}/orchestration`;
+        options.zappName = options.inputFileName;
+        options.outputDirPath = `./temp-zapps/${options.zappName}`;
+        options.parseDirPath = `${options.outputDirPath}/parse`;
+        options.circuitsDirPath = `${options.outputDirPath}/circuits`;
+        options.contractsDirPath = `${options.outputDirPath}/contracts`;
+        options.orchestrationDirPath = `${options.outputDirPath}/orchestration`;
         mkdirs(options);
-        zappify({
-            zappName,
-            inputFileName,
-            inputFilePath,
-            outputDirPath,
-            parseDirPath,
-            circuitsDirPath,
-            contractsDirPath,
-            orchestrationDirPath,
-            modifyAST,
-          });
+        zappify(options);
       });
     });
   });


### PR DESCRIPTION
This PR contains a small fix - the automated tests didn't actually zappify each zol since I mistakenly assigned the properties to the `options` object, then never used it!

This means a small bug added in internal function calls wasn't picked up, that's now fixed in `toOrchestrationVisitor`.