### PR TITLE
Hari/modifier presolc

### DIFF
--- a/src/traverse/Binding.ts
+++ b/src/traverse/Binding.ts
@@ -51,6 +51,7 @@ export class Binding {
       case 'UnaryOperation':
       case 'UserDefinedTypeName':
       case 'VariableDeclarationStatement':
+      case 'ModifierDefinition':
         return false;
       default:
         logger.error(`Hitherto unknown nodeType '${nodeType}'`);

--- a/src/traverse/Scope.ts
+++ b/src/traverse/Scope.ts
@@ -280,6 +280,7 @@ export class Scope {
       case 'UserDefinedTypeName':
       case 'VariableDeclarationStatement':
       case 'IfStatement':
+      case 'ModifierDefinition':
         break;
 
       // And again, if we haven't recognized the nodeType then we'll throw an

--- a/src/types/solidity-types.ts
+++ b/src/types/solidity-types.ts
@@ -52,6 +52,7 @@ export function getVisitableKeys(nodeType: string): string[] {
     case 'Literal':
     case 'UserDefinedTypeName':
     case 'ImportDirective':
+    case 'ModifierDefinition':
       return [];
 
     // And again, if we haven't recognized the nodeType then we'll throw an

--- a/test/contracts/modifier-2.zol
+++ b/test/contracts/modifier-2.zol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+contract Owner {
+  secret uint256 private gm_account;
+  secret uint256 private admin12;
+  secret address private admin;
+  secret address private gamer;
+
+  constructor() {
+      admin = msg.sender;
+      gamer = msg.sender;
+    }
+  modifier onlyOwner(address _account , address _player) {
+      gm_account =gm_account+3;
+      admin12 = 3;
+   require(msg.sender ==_account);
+   require(msg.sender ==_player);
+    _;
+    }
+  function alpha() private onlyOwner(admin , gamer) {
+    admin12+=1;
+    }
+}

--- a/test/contracts/modifier.zol
+++ b/test/contracts/modifier.zol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+contract Owner {
+  secret uint256 private a;
+  secret address private admin;
+  secret address private adminstartor;
+
+  constructor() {
+      admin = msg.sender;
+      adminstartor = msg.sender;
+    }
+  modifier onlyOwner() {
+      a+=3;
+   require(msg.sender == admin);
+    _;
+    }
+   modifier onlyUser() {
+   require(msg.sender == adminstartor);
+    _;
+    }
+  function alpha() private onlyOwner onlyUser {
+    a+=1;
+    }
+      function beta() private onlyOwner onlyUser {
+    a+=2;
+    }
+}


### PR DESCRIPTION
Closes #73 

In Starlight transpliation of modifiers , the  modifier body is moved into the circuit / orchestration files of function. Therefore , we can rearrange the zol contract such a way that the modifier body is copied over to function definition. 
For eg:
```
// SPDX-License-Identifier: CC0

pragma solidity ^0.8.0;

contract Owner {
  secret uint256 private a;
  secret address private admin;
  constructor() {
      admin = msg.sender;
    }
  modifier onlyOwner() {
      a+=3;
   require(msg.sender == admin);
    _;
    }
  function alpha() private onlyOwner {
    a+=1;
    }
}
```


will be rearranged to

```
// SPDX-License-Identifier: CC0

pragma solidity ^0.8.0;

contract Owner {
  secret uint256 private a;
  secret address private admin;
  constructor() {
      admin = msg.sender;
    }
  modifier onlyOwner() {
      a+=3;
   require(msg.sender == admin);
    _;
    }
  function alpha() private onlyOwner {
   require(msg.sender == admin);
    a+=1;
    }
}
```

Attaching 2 test files modifier.zol and modifier-2.zol to test functionality .