### PR TITLE
fallback and receive public states

### DIFF
--- a/src/codeGenerators/contract/solidity/toContract.ts
+++ b/src/codeGenerators/contract/solidity/toContract.ts
@@ -65,9 +65,23 @@ function codeGenerator(node: any) {
 
     case 'FunctionDefinition': {
       // prettier-ignore
-      const functionSignature = `${
-        node.isConstructor ? 'constructor ' : `function ${node.name}`
-      }(${codeGenerator(node.parameters)}) ${node.visibility} {`;
+      let functionType: string;
+      switch (node.kind)
+      {
+        case 'fallback':
+        case 'receive':
+          functionType = node.kind;
+          node.visibility = 'external payable';
+          break;
+        case 'constructor':
+          functionType = 'constructor ';
+          break;
+        case 'function':
+          functionType = `function ${node.name}`;
+          break;
+
+      }
+      const functionSignature = `${functionType} (${codeGenerator(node.parameters)}) ${node.visibility} {`;
       const body = codeGenerator(node.body);
 
 

--- a/src/transformers/visitors/ownership/errorChecksVisitor.ts
+++ b/src/transformers/visitors/ownership/errorChecksVisitor.ts
@@ -54,6 +54,8 @@ export default {
     exit(path: NodePath) {
       const { scope } = path;
       if (path.node.containsSecret && path.node.kind === 'constructor') path.node.name = 'cnstrctr';
+      if (path.node.containsSecret && (path.node.kind === 'fallback' || path.node.kind === 'receive'))
+      throw new TODOError(`Secret states on fallback / receive functions is currently not supported`, path.node);
       for (const [, indicator] of Object.entries(scope.indicators)) {
         // we may have a function indicator property we'd like to skip
         if (!(indicator instanceof StateVariableIndicator)) continue;

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -227,7 +227,7 @@ export default {
         });
       }
       node._newASTPointer.forEach(node => {
-        if(node.nodeType === 'FunctionDefinition'){
+        if(node.nodeType === 'FunctionDefinition' && (node.kind ! =='fallback' || node.kind ! == 'receive')){
           state.internalFncName?.forEach( name => {
             if(node.name === name) {
              state.postStatements ??= [];
@@ -266,11 +266,18 @@ export default {
     enter(path: NodePath, state: any) {
       const { node, parent } = path;
       const isConstructor = node.kind === 'constructor';
-      state.functionName = path.getUniqueFunctionName()
+      if(node.kind === 'fallback' || node.kind === 'receive')
+      {
+        node.fileName = node.kind;
+        state.functionName = node.kind;
+      }
+      else
+      state.functionName = path.getUniqueFunctionName();
       const newNode = buildNode('FunctionDefinition', {
         name: node.fileName || state.functionName,
         id: node.id,
-        visibility: isConstructor ? '' : 'public',
+        kind: node.kind,
+        visibility: node.kind ==='function' ? 'public' : '',
         isConstructor,
       });
 

--- a/src/types/solidity-types.ts
+++ b/src/types/solidity-types.ts
@@ -133,6 +133,7 @@ export function buildNode(nodeType: string, fields: any = {}): any {
         name,
         visibility,
         isConstructor,
+        kind,
         body = buildNode('Block'),
         parameters = buildNode('ParameterList'),
         returnParameters = buildNode('ParameterList'), // TODO
@@ -143,6 +144,7 @@ export function buildNode(nodeType: string, fields: any = {}): any {
         name,
         visibility,
         isConstructor,
+        kind,
         body,
         parameters,
         returnParameters,

--- a/test/contracts/Assign-fallback.zol
+++ b/test/contracts/Assign-fallback.zol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+contract Assign {
+
+  secret uint256 private a;
+   mapping(address => uint) balance; 
+  function add(secret uint256 value) public {
+    unknown a += value;
+  }
+
+  function remove(secret uint256 value) public {
+     a -= value;
+  }
+
+      fallback() external payable {  balance[msg.sender] += msg.value; }
+    receive() external payable {  balance[msg.sender] += msg.value; }
+}

--- a/test/error-checks/Assign-private-fallback.zol
+++ b/test/error-checks/Assign-private-fallback.zol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+contract Assign {
+
+  secret uint256 private a;
+  function add(secret uint256 value) public {
+    unknown a += value;
+  }
+
+  function remove(secret uint256 value) public {
+     a -= value;
+  }
+
+      fallback() external payable { unknown a += 2; }
+    receive() external payable { a -= 3; }
+}


### PR DESCRIPTION
closes #115 

Fallback functions has general syntax as below

```
 fallback() external [payable] {
/// code
}
```

It cannot have any arguments and has to be external payable. Since fallback function cannot have arguments , it cannot contain or modify secret states as modifying secret state require passing arguments such as nullifiers , commitments to the Shield contract.

This PR adds support for `fallback` functions with only public state modifications. Also included, support `receive()` (which works very similar to fallback and syntactically very alike ) . 

Relevant error message is thrown in case private states are modified inside `fallback()` or `receive()`. Zol files are provided for zappify test

