### PR TITLE
Swati/bug fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,8 @@ jobs:
       - name: replace zokrates image for actions test
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: "ghcr.io/eyblockchain/zokrates-worker-m1"
-          replace: "ghcr.io/eyblockchain/nightfall3-worker"
+          find: "ghcr.io/eyblockchain/zokrates-worker-m1:v1.1"
+          replace: "ghcr.io/eyblockchain/zokrates-worker-m1:v0.1"
           include: "**docker-compose.zapp.yml"
 
       - name: set up zapp

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -67,7 +67,7 @@ class FunctionBoilerplateGenerator {
       `uint256[]`,
     ])
 
-    let msgSigCheck = ([...(isConstructor ? [] : [`bytes4 sig = bytes4(keccak256("${functionName}(${parameter})")) ; \n \n \t \t \t if (sig == msg.sig)`])])
+    let msgSigCheck = ([...(isConstructor ? [] : [`bytes4 sig = bytes4(keccak256("${functionName}(${parameter})")) ;  \n \t \t \t if (sig == msg.sig)`])])
 
     return [
       `
@@ -92,7 +92,7 @@ class FunctionBoilerplateGenerator {
         inputs.newCommitments = newCommitments;`] : []),
       `
         ${msgSigCheck.join('\n')}
-        
+
         verify(proof, uint(FunctionNames.${functionName}), inputs);`,
     ];
 

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -67,8 +67,8 @@ class FunctionBoilerplateGenerator {
       `uint256[]`,
     ])
 
-    switch(isConstructor) {
-    case true :
+    let msgSigCheck = ([...(isConstructor ? [] : [`bytes4 sig = bytes4(keccak256("${functionName}(${parameter})")) ; \n \n \t \t \t if (sig == msg.sig)`])])
+
     return [
       `
         Inputs memory inputs;`,
@@ -91,41 +91,11 @@ class FunctionBoilerplateGenerator {
       ...(newCommitments ? [`
         inputs.newCommitments = newCommitments;`] : []),
       `
+        ${msgSigCheck.join('\n')}
+        
         verify(proof, uint(FunctionNames.${functionName}), inputs);`,
     ];
 
-  default :
-  return [
-     `
-      bytes4 sig = bytes4(keccak256("${functionName}(${parameter})"));`,
-
-    `
-      Inputs memory inputs;`,
-
-    `
-      inputs.customInputs = new uint[](${customInputs?.length});
-      ${customInputs?.map((name: string, i: number) => {
-        if (customInputs[i] === 'msgSender') return `inputs.customInputs[${i}] = uint256(uint160(address(msg.sender)));`
-        return `inputs.customInputs[${i}] = ${name};`;
-      }).join('\n \n \t\t\t\t\t')}`,
-
-    ...(newNullifiers ? [`
-      inputs.newNullifiers = newNullifiers;`] : []),
-
-    ...(checkNullifiers ? [`
-      inputs.checkNullifiers = checkNullifiers;`] : []),
-
-    ...(commitmentRoot ? [`
-      inputs.commitmentRoot = commitmentRoot;`] : []),
-
-    ...(newCommitments ? [`
-      inputs.newCommitments = newCommitments;`] : []),
-    `
-      if (sig == msg.sig)`,
-    `
-      verify(proof, uint(FunctionNames.${functionName}), inputs);`,
-  ];
-  }
     },
   };
 }

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -57,6 +57,7 @@ class FunctionBoilerplateGenerator {
       oldCommitmentAccessRequired: commitmentRoot,
       newCommitmentsRequired: newCommitments,
       containsAccessedOnlyState: checkNullifiers,
+      isConstructor
     }): string[] {
       // prettier-ignore
       let parameter = publicParamstype.concat([...(newNullifiers ? [`uint256[]`] : []),
@@ -66,36 +67,65 @@ class FunctionBoilerplateGenerator {
       `uint256[]`,
     ])
 
-      return [
-         `
-          bytes4 sig = bytes4(keccak256("${functionName}(${parameter})"));`,
+    switch(isConstructor) {
+    case true :
+    return [
+      `
+        Inputs memory inputs;`,
+      `
+        inputs.customInputs = new uint[](${customInputs?.length});
+        ${customInputs?.map((name: string, i: number) => {
+          if (customInputs[i] === 'msgSender') return `inputs.customInputs[${i}] = uint256(uint160(address(msg.sender)));`
+          return `inputs.customInputs[${i}] = ${name};`;
+        }).join('\n \n \t\t\t\t\t')}`,
 
-        `
-          Inputs memory inputs;`,
+      ...(newNullifiers ? [`
+        inputs.newNullifiers = newNullifiers;`] : []),
 
-        `
-          inputs.customInputs = new uint[](${customInputs?.length});
-          ${customInputs?.map((name: string, i: number) => {
-            if (customInputs[i] === 'msgSender') return `inputs.customInputs[${i}] = uint256(uint160(address(msg.sender)));`
-            return `inputs.customInputs[${i}] = ${name};`;
-          }).join('\n \n \t\t\t\t\t')}`,
+      ...(checkNullifiers ? [`
+        inputs.checkNullifiers = checkNullifiers;`] : []),
 
-        ...(newNullifiers ? [`
-          inputs.newNullifiers = newNullifiers;`] : []),
+      ...(commitmentRoot ? [`
+        inputs.commitmentRoot = commitmentRoot;`] : []),
 
-        ...(checkNullifiers ? [`
-          inputs.checkNullifiers = checkNullifiers;`] : []),
+      ...(newCommitments ? [`
+        inputs.newCommitments = newCommitments;`] : []),
+      `
+        verify(proof, uint(FunctionNames.${functionName}), inputs);`,
+    ];
 
-        ...(commitmentRoot ? [`
-          inputs.commitmentRoot = commitmentRoot;`] : []),
+  default :
+  return [
+     `
+      bytes4 sig = bytes4(keccak256("${functionName}(${parameter})"));`,
 
-        ...(newCommitments ? [`
-          inputs.newCommitments = newCommitments;`] : []),
-        `
-          if (sig == msg.sig)`,
-        `
-          verify(proof, uint(FunctionNames.${functionName}), inputs);`,
-      ];
+    `
+      Inputs memory inputs;`,
+
+    `
+      inputs.customInputs = new uint[](${customInputs?.length});
+      ${customInputs?.map((name: string, i: number) => {
+        if (customInputs[i] === 'msgSender') return `inputs.customInputs[${i}] = uint256(uint160(address(msg.sender)));`
+        return `inputs.customInputs[${i}] = ${name};`;
+      }).join('\n \n \t\t\t\t\t')}`,
+
+    ...(newNullifiers ? [`
+      inputs.newNullifiers = newNullifiers;`] : []),
+
+    ...(checkNullifiers ? [`
+      inputs.checkNullifiers = checkNullifiers;`] : []),
+
+    ...(commitmentRoot ? [`
+      inputs.commitmentRoot = commitmentRoot;`] : []),
+
+    ...(newCommitments ? [`
+      inputs.newCommitments = newCommitments;`] : []),
+    `
+      if (sig == msg.sig)`,
+    `
+      verify(proof, uint(FunctionNames.${functionName}), inputs);`,
+  ];
+  }
     },
   };
 }

--- a/src/codeGenerators/contract/solidity/toContract.ts
+++ b/src/codeGenerators/contract/solidity/toContract.ts
@@ -172,8 +172,10 @@ function codeGenerator(node: any) {
 
     }
     case 'InternalFunctionCall' :{
-      if(node.parameters){
+      if(node.parameters ){
+        if(node.internalFunctionInteractsWithSecret)
          return `\t \t \t \t ${node.name} (${node.parameters});`
+        return  `\t \t \t \t ${node.name} (${node.parameters.map(codeGenerator)});`
       } else {
          return `\t \t \t \t${node.name} (${node.arguments.name});`
       }

--- a/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
@@ -1,6 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import NodePath from '../../traverse/NodePath.js';
-
+import { FunctionDefinitionIndicator } from '../../traverse/Indicator.js';
+import buildNode from '../../types/orchestration-types.js'
 
 
 
@@ -13,12 +14,11 @@ const internalCallVisitor = {
    exit(path: NodePath, state: any) {
 
      // Find the Internal Function Node,
-
      const { node, parent } = path;
-
      node._newASTPointer.forEach(file => {
-      state.internalFncName?.forEach( (name, index) => {
+      state.internalFncName?.forEach( name => {
         if(file.fileName === name) {
+          let index = state.internalFncName.indexOf(name);
           if(state.circuitImport[index]==='true') {
             file.nodes.forEach(childNode => {
               if(childNode.nodeType === 'FunctionDefinition'){
@@ -34,7 +34,7 @@ const internalCallVisitor = {
                  })
                  state.newParameterList.forEach(node => {
                   if(node.nodeType === 'Boilerplate') {
-                    for(const [index, oldStateName] of  state.oldStateArray?.entries()) {
+                    for(const [index, oldStateName] of  state.oldStateArray.entries()) {
                       node.name = node.name.replace('_'+oldStateName, '_'+state.newStateArray[index])
                       if(node.newCommitmentValue === oldStateName)
                        node.newCommitmentValue = node.newCommitmentValue.replace(oldStateName, state.newStateArray[index])
@@ -43,7 +43,7 @@ const internalCallVisitor = {
                      }
                    }
                    if(node.nodeType === 'VariableDeclaration'){
-                     for(const [index, oldStateName] of state.oldStateArray?.entries()) {
+                     for(const [index, oldStateName] of state.oldStateArray.entries()) {
                        node.name = node.name.replace(oldStateName, state.newStateArray[index])
                      }
                    }
@@ -124,6 +124,7 @@ const internalCallVisitor = {
                   if(node.nodeType === 'ExpressionStatement') {
                     if(node.expression.nodeType === 'Assignment') {
                       let  expressionList = cloneDeep(node);
+                      console.log()
                       for(const [index, oldStateName] of  state.oldStateArray.entries()) {
                         if(node.expression.rightHandSide.rightExpression.name === oldStateName)
                          expressionList.expression.rightHandSide.rightExpression.name = expressionList.expression.rightHandSide.rightExpression.name.replace(oldStateName, state.newStateArray[index])

--- a/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
@@ -1,7 +1,6 @@
 import cloneDeep from 'lodash.clonedeep';
 import NodePath from '../../traverse/NodePath.js';
-import { FunctionDefinitionIndicator } from '../../traverse/Indicator.js';
-import buildNode from '../../types/orchestration-types.js'
+
 
 
 

--- a/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
@@ -124,7 +124,6 @@ const internalCallVisitor = {
                   if(node.nodeType === 'ExpressionStatement') {
                     if(node.expression.nodeType === 'Assignment') {
                       let  expressionList = cloneDeep(node);
-                      console.log()
                       for(const [index, oldStateName] of  state.oldStateArray.entries()) {
                         if(node.expression.rightHandSide.rightExpression.name === oldStateName)
                          expressionList.expression.rightHandSide.rightExpression.name = expressionList.expression.rightHandSide.rightExpression.name.replace(oldStateName, state.newStateArray[index])

--- a/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
@@ -6,8 +6,6 @@ import NodePath from '../../traverse/NodePath.js';
 
 
 // let interactsWithSecret = false; // Added globaly as two objects are accesing it
-let oldStateArray : string[];
- let circuitImport = [];
 
 const internalCallVisitor = {
  ContractDefinition: {
@@ -15,12 +13,13 @@ const internalCallVisitor = {
    exit(path: NodePath, state: any) {
 
      // Find the Internal Function Node,
+
      const { node, parent } = path;
+
      node._newASTPointer.forEach(file => {
-      state.internalFncName?.forEach( name => {
+      state.internalFncName?.forEach( (name, index) => {
         if(file.fileName === name) {
-          let index = state.internalFncName.indexOf(name);
-          if(circuitImport[index]==='true') {
+          if(state.circuitImport[index]==='true') {
             file.nodes.forEach(childNode => {
               if(childNode.nodeType === 'FunctionDefinition'){
                 state.newParameterList = cloneDeep(childNode.parameters.parameters);
@@ -35,7 +34,7 @@ const internalCallVisitor = {
                  })
                  state.newParameterList.forEach(node => {
                   if(node.nodeType === 'Boilerplate') {
-                    for(const [index, oldStateName] of  oldStateArray.entries()) {
+                    for(const [index, oldStateName] of  state.oldStateArray?.entries()) {
                       node.name = node.name.replace('_'+oldStateName, '_'+state.newStateArray[index])
                       if(node.newCommitmentValue === oldStateName)
                        node.newCommitmentValue = node.newCommitmentValue.replace(oldStateName, state.newStateArray[index])
@@ -44,7 +43,7 @@ const internalCallVisitor = {
                      }
                    }
                    if(node.nodeType === 'VariableDeclaration'){
-                     for(const [index, oldStateName] of oldStateArray.entries()) {
+                     for(const [index, oldStateName] of state.oldStateArray?.entries()) {
                        node.name = node.name.replace(oldStateName, state.newStateArray[index])
                      }
                    }
@@ -117,7 +116,7 @@ const internalCallVisitor = {
                }
              })
            }
-          else if(circuitImport[index] === 'false'){
+          else if(state.circuitImport[index] === 'false'){
             let newExpressionList = [];
             file.nodes.forEach(childNode => {
               if(childNode.nodeType === 'FunctionDefinition'){
@@ -125,7 +124,7 @@ const internalCallVisitor = {
                   if(node.nodeType === 'ExpressionStatement') {
                     if(node.expression.nodeType === 'Assignment') {
                       let  expressionList = cloneDeep(node);
-                      for(const [index, oldStateName] of  oldStateArray.entries()) {
+                      for(const [index, oldStateName] of  state.oldStateArray.entries()) {
                         if(node.expression.rightHandSide.rightExpression.name === oldStateName)
                          expressionList.expression.rightHandSide.rightExpression.name = expressionList.expression.rightHandSide.rightExpression.name.replace(oldStateName, state.newStateArray[index])
                         if(node.expression.leftHandSide.name === oldStateName)

--- a/src/transformers/visitors/common.ts
+++ b/src/transformers/visitors/common.ts
@@ -21,20 +21,19 @@ export const internalFunctionCallVisitor = (thisPath: NodePath, thisState: any) 
  if(node.expression.nodeType === 'Identifier') {
   const functionReferncedNode = scope.getReferencedNode(node.expression);
   const params = functionReferncedNode.parameters.parameters;
+  if((params.length !== 0) && (params.some(node => node.isSecret)))
+  {
+    thisState.internalFunctionInteractsWithSecret = true;
+} else
+thisState.internalFunctionInteractsWithSecret = false;
   oldStateArray = params.map(param => (param.name) );
   for (const [index, param] of params.entries()) {
     if(isSecretArray[index] !== param.isSecret)
     parametercheck = false;
     break;
   }
-  const fnIndicator : FunctionDefinitionIndicator = scope.indicators;
-  if(parametercheck && fnIndicator.internalFunctionInteractsWithSecret){
-  thisState.internalFunctionInteractsWithSecret = true;
-   }
-   if(!fnIndicator.internalFunctionInteractsWithSecret){
-       if(params.some(node => node.isSecret))
-       {
-       thisState.internalFunctionInteractsWithSecret = true; }
+  if(parametercheck && thisState.internalFunctionInteractsWithSecret){
+  thisState.isInternalFunctionCallValid = true;
    }
  }
  return oldStateArray;
@@ -49,7 +48,7 @@ export const internalFunctionCallVisitor = (thisPath: NodePath, thisState: any) 
   let path = oldAST;
 
   if(type !== 'orchestration')
-  { 
+  {
     const dummyParent = {
       ast: oldAST,
     };
@@ -88,4 +87,3 @@ export function parentnewASTPointer(parent:any , path:any , newNode:any, type:an
     parent._newASTPointer[path.containerName] = newNode;
   }
 }
-

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -232,7 +232,9 @@ const internalCallVisitor = {
              if(file.fileName === state.callingFncName[index]) {
                file.nodes.forEach(childNode => {
                  if(childNode.nodeType === 'FunctionDefinition') {
+
                    childNode.body.statements.forEach(node => {
+                     console.log((node.nodeType === 'ExpressionStatement' && node.expression.name === state.internalFncName[index]))
                      if(node.nodeType === 'ExpressionStatement' && node.expression.name === state.internalFncName[index]) {
                        state.newStatementList.forEach(list => {
                          if(list.nodeType === 'VariableDeclarationStatement')
@@ -242,11 +244,17 @@ const internalCallVisitor = {
                         })
                       }
                     });
+                    console.log(state.newStatementList);
                   }
+
                 })
+
               }
+
             })
+
           }
+
         }
       })
     })

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -232,19 +232,18 @@ const internalCallVisitor = {
              if(file.fileName === state.callingFncName[index]) {
                file.nodes.forEach(childNode => {
                  if(childNode.nodeType === 'FunctionDefinition') {
-
                    childNode.body.statements.forEach(node => {
-                     console.log((node.nodeType === 'ExpressionStatement' && node.expression.name === state.internalFncName[index]))
-                     if(node.nodeType === 'ExpressionStatement' && node.expression.name === state.internalFncName[index]) {
+                     if(node.nodeType === 'VariableDeclarationStatement') {
                        state.newStatementList.forEach(list => {
-                         if(list.nodeType === 'VariableDeclarationStatement')
-                          node.expression = Object.assign(node.expression,list.initialValue);
-                          if(list.nodeType === 'Assignment')
-                          childNode.body.statements?.splice(childNode.body.statements.indexOf(node)+1, 0, list);
+                         if(list.nodeType === 'VariableDeclarationStatement' && node.declarations[0].name === list.declarations[0].name)
+                         childNode.body.statements.splice(childNode.body.statements.indexOf(node)+2, 0, list.initialValue);
+                         // Added 2 to the index as next element in the array will be the Assigment node and we want to add after that
+                         if(list.nodeType === 'Assignment')
+                         childNode.body.statements.splice(childNode.body.statements.indexOf(node)+3, 0, list);
+                         // Added 3 to the index as we want to add assigment node after the above node
                         })
                       }
                     });
-                    console.log(state.newStatementList);
                   }
 
                 })

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -18,9 +18,8 @@ const internalCallVisitor = {
       let sendTransactionNode : any;
       let newdecrementedSecretStates = [];
       node._newASTPointer.forEach(file => {
-       state.internalFncName?.forEach( name => {
+       state.internalFncName?.forEach( (name, index) => {
          if(file.fileName === name && file.nodeType === 'File') {
-           let index = state.internalFncName.indexOf(name);
            if(state.circuitImport[index]==='true') {
              file.nodes.forEach(childNode => {
                if(childNode.nodeType === 'FunctionDefinition'){
@@ -202,16 +201,14 @@ const internalCallVisitor = {
                      if(node.nodeType === 'GenerateProof'){
                        node.privateStates = Object.assign(node.privateStates,generateProofNode.privateStates)
                        node.parameters = [...new Set([...node.parameters ,...generateProofNode.parameters])];
-                      }
+                     }
 
-                      if(node.nodeType === 'SendTransaction')
+                    if(node.nodeType === 'SendTransaction')
                        node.privateStates = Object.assign(node.privateStates,sendTransactionNode.privateStates)
 
-                      if(node.nodeType === 'WritePreimage')
+                    if(node.nodeType === 'WritePreimage')
                        node.privateStates = Object.assign(node.privateStates,writePreimageNode.privateStates)
-
                     })
-
                   }
                 })
               }
@@ -268,7 +265,6 @@ FunctionCall: {
       oldStateArray = internalFunctionCallVisitor(path, newState)
       internalFunctionInteractsWithSecret ||= newState.internalFunctionInteractsWithSecret;
       isInternalFunctionCallValid  ||= newState.isInternalFunctionCallValid;
-      console.log(internalFunctionInteractsWithSecret);
       state.internalFncName ??= [];
       state.internalFncName.push(node.expression.name);
      if(isInternalFunctionCallValid  === true) {

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -221,8 +221,8 @@ const internalCallVisitor = {
                state.newStatementList.forEach(node => {
                  if(node.nodeType === 'VariableDeclarationStatement') {
                    for(const [index, oldStateName] of  oldStateArray.entries()) {
-                     node.initialValue.leftHandSide.name = node.initialValue.leftHandSide.name.replace('_'+oldStateName, '_'+ state.newStateArray[index]);
-                     node.initialValue.rightHandSide.name = node.initialValue.rightHandSide.name.replace(oldStateName,  state.newStateArray[index]);
+                     node.initialValue.leftHandSide.name = node.initialValue.leftHandSide.name?.replace('_'+oldStateName, '_'+ state.newStateArray[index]);
+                     node.initialValue.rightHandSide.name = node.initialValue.rightHandSide.name?.replace(oldStateName,  state.newStateArray[index]);
                     }
                   }
                 })

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -743,7 +743,7 @@ const visitor = {
                    break;
                   }
                   state.circuitImport ??= []
-                  state.circuitImport.push('true');
+                  state.circuitImport.push('false');
                  isCircuit = false;
                 }
               }
@@ -762,7 +762,7 @@ const visitor = {
           }
             else{
             state.circuitImport ??= []
-            state.circuitImport.push('true');
+            state.circuitImport.push('false');
           }
             }
             }

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -48,8 +48,6 @@ const publicInputsVisitor = (thisPath: NodePath, thisState: any) => {
 };
 
 let interactsWithSecret = false; // Added globaly as two objects are accesing it
-let oldStateArray : string[];
-let circuitImport = [];
 /**
  * @desc:
  * Visitor transforms a `.zol` AST into a `.zok` AST
@@ -724,7 +722,7 @@ const visitor = {
         state.newStateArray =  args.map(arg => (arg.name));
         let internalFunctionInteractsWithSecret = false;
         const newState: any = {};
-        oldStateArray = internalFunctionCallVisitor(path, newState)
+        state.oldStateArray = internalFunctionCallVisitor(path, newState)
         internalFunctionInteractsWithSecret ||= newState.internalFunctionInteractsWithSecret;
         state.internalFncName ??= [];
         state.internalFncName.push(node.expression.name);
@@ -737,13 +735,15 @@ const visitor = {
          startNodePath.node.nodes.forEach(node => {
            if(node.nodeType === 'VariableDeclaration'){
              if(node.typeName.nodeType === 'Mapping') {
-               for(const [index, oldStateName] of  oldStateArray.entries()) {
+               for(const [index, oldStateName] of  state.oldStateArray.entries()) {
                  if(oldStateName !== state.newStateArray[index]){
-                   circuitImport.push('true');
+                   state.circuitImport ??= []
+                   state.circuitImport.push('true');
                    isCircuit = true;
                    break;
                   }
-                 circuitImport.push('false');
+                  state.circuitImport ??= []
+                  state.circuitImport.push('true');
                  isCircuit = false;
                 }
               }
@@ -756,10 +756,14 @@ const visitor = {
                 }
               else
                 isCircuit = true;
-            if(isCircuit)
-              circuitImport.push('true');
-            else
-              circuitImport.push('false');
+            if(isCircuit){
+            state.circuitImport ??= []
+            state.circuitImport.push('true');
+          }
+            else{
+            state.circuitImport ??= []
+            state.circuitImport.push('true');
+          }
             }
             }
           });

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -8,7 +8,7 @@ import NodePath from '../../traverse/NodePath.js';
 import explode from './explode.js';
 import internalCallVisitor from './circuitInternalFunctionCallVisitor.js';
 import { VariableBinding } from '../../traverse/Binding.js';
-import { StateVariableIndicator, FunctionDefinitionIndicator} from '../../traverse/Indicator.js';
+import { StateVariableIndicator} from '../../traverse/Indicator.js';
 import { interactsWithSecretVisitor, internalFunctionCallVisitor, parentnewASTPointer } from './common.js';
 
 // below stub will only work with a small subtree - passing a whole AST will always give true!
@@ -640,7 +640,7 @@ const visitor = {
       parent._newASTPointer.push(newNode);
     },
   },
-  
+
   Literal: {
     enter(path: NodePath) {
       const { node, parent , parentPath } = path;

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -7,7 +7,7 @@ import { traverseNodesFast } from '../../traverse/traverse.js';
 import NodePath from '../../traverse/NodePath.js';
 import { VariableBinding } from '../../traverse/Binding.js';
 import { ContractDefinitionIndicator,FunctionDefinitionIndicator } from '../../traverse/Indicator.js';
-import { interactsWithSecretVisitor, parentnewASTPointer } from './common.js';
+import { interactsWithSecretVisitor, parentnewASTPointer, internalFunctionCallVisitor } from './common.js';
 
 // here we find any public state variables which interact with secret states
 // and hence need to be included in the verification calculation
@@ -66,8 +66,6 @@ const findCustomInputsVisitor = (thisPath: NodePath, thisState: any) => {
   }
 };
 
-
-let internalFuncInteractsWithSecret = false;
 /**
  * @desc:
  * Visitor transforms a `.zol` AST into a `.sol` AST (for a 'shield' contract)
@@ -210,10 +208,8 @@ export default {
         ...buildNode('ContractBoilerplate', {
           bpSection: 'stateVariableDeclarations',
           scope,
-          internalFuncInteractsWithSecret,
         }),
       );
-
       if (state.mainPrivateFunctionName) {
         parent._newASTPointer[0].mainPrivateFunctionName =
           state.mainPrivateFunctionName; // TODO fix bodge
@@ -222,14 +218,15 @@ export default {
             node.mainPrivateFunctionName = state.mainPrivateFunctionName;
         });
       }
+
       node._newASTPointer.forEach(node => {
         if(node.nodeType === 'FunctionDefinition'){
-          state.internalFncName?.forEach( name => {
+          state.internalFncName?.forEach((name, index) => {
             if(node.name === name) {
              state.postStatements ??= [];
              state.postStatements = cloneDeep(node.body.postStatements);
             }
-            if(node.name === state.callingFncName[state.internalFncName.indexOf(name)]){
+            if(node.name === state.callingFncName[index]){
              node.body.postStatements.forEach( childNode => {
                state.postStatements?.forEach(node => {
                  if(!childNode.nullifiersRequired && node.nullifiersRequired)
@@ -707,16 +704,17 @@ export default {
       if (path.isInternalFunctionCall()) {
         // External function calls are the fiddliest of things, because they must be retained in the Solidity contract, rather than brought into the circuit. With this in mind, it's easiest (from the pov of writing this transpiler) if External function calls appear at the very start or very end of a function. If they appear interspersed around the middle, we'd either need multiple circuits per Zolidity function, or we'd need a set of circuit parameters (non-secret params / return-params) per external function call, and both options are too painful for now.
         // TODO: need a warning message to this effect ^^^
-       const fnIndicator : FunctionDefinitionIndicator = scope.indicators;
-       internalFuncInteractsWithSecret = fnIndicator.internalFunctionInteractsWithSecret;
+
        const functionReferncedNode = scope.getReferencedNode(node.expression);
        const params = functionReferncedNode.parameters.parameters;
-       if(!fnIndicator.internalFunctionInteractsWithSecret){
-         if(params.some(node => node.isSecret))
-          internalFuncInteractsWithSecret = true;
-        }
+       if((params.length !== 0) && (params.some(node => node.isSecret)))
+       {
+         state.internalFunctionInteractsWithSecret = true;
+     } else
+     state.internalFunctionInteractsWithSecret = false;
 
-        if(internalFuncInteractsWithSecret){
+
+        if(state.internalFunctionInteractsWithSecret){
           state.internalFncName ??= [];
           state.internalFncName.push(node.expression.name);
           const fnDefNode = path.getAncestorOfType('FunctionDefinition');
@@ -731,13 +729,29 @@ export default {
           ]
           newNode = buildNode('InternalFunctionCall', {
           name: node.expression.name,
-          internalFunctionInteractsWithSecret: internalFuncInteractsWithSecret,
+          internalFunctionInteractsWithSecret: state.internalFunctionInteractsWithSecret,
           parameters: state.fnParameters,
          });
          node._newASTPointer = newNode;
          parentnewASTPointer(parent, path, newNode , parent._newASTPointer[path.containerName]);
          return;
-        }
+       } else if(!state.internalFunctionInteractsWithSecret){
+         state.internalFncName ??= [];
+         state.internalFncName.push(node.expression.name);
+         console.log(node);
+         const fnDefNode = path.getAncestorOfType('FunctionDefinition');
+         state.callingFncName ??= [];
+         state.callingFncName.push(fnDefNode.node.name);
+         newNode = buildNode('InternalFunctionCall', {
+         name: node.expression.name,
+         internalFunctionInteractsWithSecret: state.internalFunctionInteractsWithSecret,
+         parameters: node.arguments,
+        });
+        node._newASTPointer = newNode;
+        parentnewASTPointer(parent, path, newNode , parent._newASTPointer[path.containerName]);
+        return;
+       }
+
         newNode = buildNode('FunctionCall');
         node._newASTPointer = newNode;
         parentnewASTPointer(parent, path, newNode , parent._newASTPointer[path.containerName]);

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -221,7 +221,7 @@ export default {
 
       node._newASTPointer.forEach(node => {
         if(node.nodeType === 'FunctionDefinition' && (node.kind ! =='fallback' || node.kind ! == 'receive')){
-          state.internalFncName?.forEach( name => {
+          state.internalFncName?.forEach( (name, index) => {
             if(node.name === name) {
              state.postStatements ??= [];
              state.postStatements = cloneDeep(node.body.postStatements);

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -220,7 +220,8 @@ export default {
       }
 
       node._newASTPointer.forEach(node => {
-        if(node.nodeType === 'FunctionDefinition' && (node.kind ! =='fallback' || node.kind ! == 'receive')){
+
+        if(node.nodeType === 'FunctionDefinition' && node.kind === 'function'){
           state.internalFncName?.forEach( (name, index) => {
             if(node.name === name) {
              state.postStatements ??= [];
@@ -249,7 +250,6 @@ export default {
               })
             }
           });
-
         }
       })
     },

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -738,7 +738,6 @@ export default {
        } else if(!state.internalFunctionInteractsWithSecret){
          state.internalFncName ??= [];
          state.internalFncName.push(node.expression.name);
-         console.log(node);
          const fnDefNode = path.getAncestorOfType('FunctionDefinition');
          state.callingFncName ??= [];
          state.callingFncName.push(fnDefNode.node.name);

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -10,7 +10,7 @@ import buildNode from '../../types/orchestration-types.js';
 import { buildPrivateStateNode } from '../../boilerplate/orchestration/javascript/nodes/boilerplate-generator.js';
 import explode from './explode.js';
 import internalCallVisitor from './orchestrationInternalFunctionCallVisitor.js';
-import { interactsWithSecretVisitor, parentnewASTPointer } from './common.js';
+import { interactsWithSecretVisitor, parentnewASTPointer, internalFunctionCallVisitor } from './common.js';
 
 // collects increments and decrements into a string (for new commitment calculation) and array
 // (for collecting zokrates inputs)
@@ -295,6 +295,7 @@ const visitor = {
       };
       // By this point, we've added a corresponding FunctionDefinition node to the newAST, with the same nodes as the original Solidity function, with some renaming here and there, and stripping out unused data from the oldAST.
       const functionIndicator: FunctionDefinitionIndicator = scope.indicators;
+
       let thisIntegrationTestFunction: any = {};
       for (const file of parent._newASTPointer) {
         if (file.nodes?.[0].nodeType === 'IntegrationTestBoilerplate') {
@@ -312,8 +313,7 @@ const visitor = {
       if (
         ((functionIndicator.newCommitmentsRequired ||
           functionIndicator.nullifiersRequired) &&
-        scope.modifiesSecretState()) || functionIndicator.internalFunctionInteractsWithSecret
-      ) {
+        scope.modifiesSecretState()) ) {
         const newNodes = initialiseOrchestrationBoilerplateNodes(
           functionIndicator,
         );

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1,7 +1,4 @@
 /* eslint-disable no-param-reassign, no-shadow, no-unused-vars, no-continue */
-
-// import logger from '../../utils/logger.js';
-import cloneDeep from 'lodash.clonedeep';
 import NodePath from '../../traverse/NodePath.js';
 import { StateVariableIndicator, FunctionDefinitionIndicator } from '../../traverse/Indicator.js';
 import { VariableBinding } from '../../traverse/Binding.js';
@@ -10,7 +7,7 @@ import buildNode from '../../types/orchestration-types.js';
 import { buildPrivateStateNode } from '../../boilerplate/orchestration/javascript/nodes/boilerplate-generator.js';
 import explode from './explode.js';
 import internalCallVisitor from './orchestrationInternalFunctionCallVisitor.js';
-import { interactsWithSecretVisitor, parentnewASTPointer, internalFunctionCallVisitor } from './common.js';
+import { interactsWithSecretVisitor, parentnewASTPointer } from './common.js';
 
 // collects increments and decrements into a string (for new commitment calculation) and array
 // (for collecting zokrates inputs)
@@ -261,7 +258,7 @@ const visitor = {
       const { node, parent, scope } = path;
       state.msgSenderParam ??= scope.indicators.msgSenderParam;
       node._newASTPointer.msgSenderParam ??= state.msgSenderParam;
-      const initialiseOrchestrationBoilerplateNodes = (fnIndicator) => {
+      const initialiseOrchestrationBoilerplateNodes = (fnIndicator: FunctionDefinitionIndicator) => {
         const newNodes: any = {};
         const contractName = `${parent.name}Shield`;
         newNodes.InitialiseKeysNode = buildNode('InitialiseKeys', {
@@ -277,7 +274,7 @@ const visitor = {
           });
           newNodes.calculateNullifierNode = buildNode('CalculateNullifier');
         }
-        if (fnIndicator.newCommitmentsRequired)
+        if (fnIndicator.newCommitmentsRequired || fnIndicator.internalFunctionInteractsWithSecret)
           newNodes.calculateCommitmentNode = buildNode('CalculateCommitment');
           newNodes.generateProofNode = buildNode('GenerateProof', {
           circuitName: node.fileName,
@@ -313,7 +310,7 @@ const visitor = {
       if (
         ((functionIndicator.newCommitmentsRequired ||
           functionIndicator.nullifiersRequired) &&
-        scope.modifiesSecretState()) ) {
+        scope.modifiesSecretState()) || functionIndicator.internalFunctionInteractsWithSecret ) {
         const newNodes = initialiseOrchestrationBoilerplateNodes(
           functionIndicator,
         );

--- a/src/traverse/Indicator.ts
+++ b/src/traverse/Indicator.ts
@@ -92,18 +92,15 @@ export class FunctionDefinitionIndicator extends ContractDefinitionIndicator {
 
     }
 
-//console.log(path.node.typeDescriptions);
     if(path.node.typeDescriptions.typeIdentifier.includes(`_internal_`))
       {
         const functionReferncedNode = path.scope.getReferencedNode(path.node);
         const params = functionReferncedNode.parameters.parameters ;
-          if(params.some(node => node.isSecret))
+          if (params.some(node => node.isSecret))
           {
             this.internalFunctionInteractsWithSecret = true;
         }
-      //console.log(this.internalFunctionInteractsWithSecret);
     }
-
   }
 
   updateIncrementation(path: NodePath, state: any) {

--- a/test/contracts/internalFunctionCallTest1.zol
+++ b/test/contracts/internalFunctionCallTest1.zol
@@ -5,13 +5,13 @@ pragma solidity ^0.8.0;
 contract Assign {
 
   secret uint256 private a;
-  
+
   function remove(secret uint256 value) public {
     a -= value;
     add(value);
   }
   function add(secret uint256 value) public {
-    known a += value;
+    known a = a + 2 * value;
   }
 
 

--- a/test/contracts/internalFunctionCallTest2.zol
+++ b/test/contracts/internalFunctionCallTest2.zol
@@ -13,7 +13,7 @@ contract Assign {
   }
 
   function addA(secret uint256 value) public {
-    known a += value;
+    known a = a + 2 * value;
   }
   function remove(secret uint256 value) public {
     a -= value;

--- a/test/contracts/internalFunctionTest4.zol
+++ b/test/contracts/internalFunctionTest4.zol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0
+pragma solidity ^0.8.0;
+contract Assign {
+  secret uint256 private a;
+  secret uint256 private b;
+  function addB(secret uint256 value) public {
+    known b += value;
+  }
+
+
+  function addA(secret uint256 value) public {
+    known a += value;
+  }
+  function remove(secret uint256 value) public {
+    addB(value);
+    addA(value);
+  }
+
+  function addfn(secret uint256 value) public {
+  addA(value);
+    }
+}

--- a/test/contracts/internalFunctionTest5.zol
+++ b/test/contracts/internalFunctionTest5.zol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: CC0
+pragma solidity ^0.8.0;
+contract Assign {
+  secret uint256 private a;
+  secret uint256 private b;
+  uint256 public c;
+  function addB(secret uint256 value) public {
+    known b += value;
+  }
+    function addC() public {
+    c += 2;
+  }
+  function addA(secret uint256 value) public {
+    known a += value;
+  }
+  function remove(secret uint256 value) public {
+    addB(value);
+    addA(value);
+    addC();
+  }
+}


### PR DESCRIPTION
This closes the issues #125  and #111 .
Both the bugs are fixed.
For  #111 , we removed `msg.sig` for `constructors`. 
For #125 , we modified `visitors` for mixed internal function calls
