### PR TITLE
Swati/accessed indicator bug fix

### DIFF
--- a/src/transformers/visitors/checks/internalCallVisitor.ts
+++ b/src/transformers/visitors/checks/internalCallVisitor.ts
@@ -29,7 +29,6 @@ export default {
                 throw new Error('Make sure that passed parameters have same decorators');
              }
          });
-
          const thisFunctionIndicator = path.scope.indicators;
          thisFunctionIndicator.internalFunctionInteractsWithSecret ??= functionReferencedPath.scope.indicators.interactsWithSecret;
          thisFunctionIndicator.internalFunctionModifiesSecretState ??= functionReferencedPath.scope.modifiesSecretState();

--- a/src/transformers/visitors/checks/internalCallVisitor.ts
+++ b/src/transformers/visitors/checks/internalCallVisitor.ts
@@ -31,7 +31,6 @@ export default {
          });
 
          const thisFunctionIndicator = path.scope.indicators;
-         
          thisFunctionIndicator.internalFunctionInteractsWithSecret ??= functionReferencedPath.scope.indicators.interactsWithSecret;
          thisFunctionIndicator.internalFunctionModifiesSecretState ??= functionReferencedPath.scope.modifiesSecretState();
       }

--- a/src/transformers/visitors/common.ts
+++ b/src/transformers/visitors/common.ts
@@ -21,7 +21,7 @@ export const initialiseOrchestrationBoilerplateNodes = (fnIndicator: FunctionDef
     contractName,
     onChainKeyRegistry: fnIndicator.onChainKeyRegistry,
   });
-  if (fnIndicator.oldCommitmentAccessRequired)
+  if (fnIndicator.oldCommitmentAccessRequired || fnIndicator.internalFunctionoldCommitmentAccessRequired)
     newNodes.initialisePreimageNode = buildNode('InitialisePreimage');
   newNodes.readPreimageNode = buildNode('ReadPreimage', {
     contractName,

--- a/src/transformers/visitors/common.ts
+++ b/src/transformers/visitors/common.ts
@@ -19,8 +19,9 @@ export const internalFunctionCallVisitor = (thisPath: NodePath, thisState: any) 
      isSecretArray = args.map(arg => scope.getReferencedBinding(arg).isSecret);
  }
  if(node.expression.nodeType === 'Identifier') {
-  const functionReferncedNode = scope.getReferencedNode(node.expression);
-  const params = functionReferncedNode.parameters.parameters;
+  const functionReferncedNode = scope.getReferencedPath(node.expression);
+  const params = functionReferncedNode.node.parameters.parameters;
+  thisPath.scope.indicators.internalFunctionoldCommitmentAccessRequired = functionReferncedNode.scope.indicators.oldCommitmentAccessRequired;
   if((params.length !== 0) && (params.some(node => (node.isSecret || node._newASTPointer?.interactsWithSecret))))
   {
     thisState.internalFunctionInteractsWithSecret = true;

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -385,6 +385,7 @@ FunctionCall: {
       }
       let internalFunctionInteractsWithSecret = false;
       const newState: any = {};
+      const newNodes: any = {};
       oldStateArray = internalFunctionCallVisitor(path, newState)
       internalFunctionInteractsWithSecret ||= newState.internalFunctionInteractsWithSecret;
       state.internalFncName ??= [];
@@ -394,7 +395,6 @@ FunctionCall: {
        const callingfnDefIndicators = callingfnDefPath.scope.indicators;
        const functionReferncedNode = scope.getReferencedPath(node.expression);
        const internalfnDefIndicators = functionReferncedNode.scope.indicators;
-       callingfnDefIndicators.internalFunctionoldCommitmentAccessRequired = internalfnDefIndicators.oldCommitmentAccessRequired;
        const startNodePath = path.getAncestorOfType('ContractDefinition')
        startNodePath.node.nodes.forEach(node => {
          if(node.nodeType === 'VariableDeclaration'){

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -385,7 +385,6 @@ FunctionCall: {
       }
       let internalFunctionInteractsWithSecret = false;
       const newState: any = {};
-      const newNodes: any = {};
       oldStateArray = internalFunctionCallVisitor(path, newState)
       internalFunctionInteractsWithSecret ||= newState.internalFunctionInteractsWithSecret;
       state.internalFncName ??= [];

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -394,6 +394,7 @@ FunctionCall: {
        const callingfnDefIndicators = callingfnDefPath.scope.indicators;
        const functionReferncedNode = scope.getReferencedPath(node.expression);
        const internalfnDefIndicators = functionReferncedNode.scope.indicators;
+       callingfnDefIndicators.internalFunctionoldCommitmentAccessRequired = internalfnDefIndicators.oldCommitmentAccessRequired;
        const startNodePath = path.getAncestorOfType('ContractDefinition')
        startNodePath.node.nodes.forEach(node => {
          if(node.nodeType === 'VariableDeclaration'){

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -306,7 +306,6 @@ const visitor = {
           contractName,
           onChainKeyRegistry: fnIndicator.onChainKeyRegistry,
         });
-
         if (fnIndicator.oldCommitmentAccessRequired || fnIndicator.internalFunctionoldCommitmentAccessRequired)
           newNodes.initialisePreimageNode = buildNode('InitialisePreimage');
         newNodes.readPreimageNode = buildNode('ReadPreimage', {
@@ -1278,12 +1277,6 @@ const visitor = {
       });
       node._newASTPointer = newNode;
       parent._newASTPointer[path.containerName] = newNode;
-
-     if(path.isInternalFunctionCall()) {
-      state.isInternalFunctionCall = true;
-      console.log('entered path');
-     }
-
     },
   },
 };

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -306,7 +306,8 @@ const visitor = {
           contractName,
           onChainKeyRegistry: fnIndicator.onChainKeyRegistry,
         });
-        if (fnIndicator.oldCommitmentAccessRequired|| fnIndicator.parentIndicator.oldCommitmentAccessRequired)
+
+        if (fnIndicator.oldCommitmentAccessRequired || fnIndicator.internalFunctionoldCommitmentAccessRequired)
           newNodes.initialisePreimageNode = buildNode('InitialisePreimage');
         newNodes.readPreimageNode = buildNode('ReadPreimage', {
           contractName,
@@ -1278,6 +1279,10 @@ const visitor = {
       node._newASTPointer = newNode;
       parent._newASTPointer[path.containerName] = newNode;
 
+     if(path.isInternalFunctionCall()) {
+      state.isInternalFunctionCall = true;
+      console.log('entered path');
+     }
 
     },
   },

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -304,39 +304,7 @@ const visitor = {
       state.msgSenderParam ??= scope.indicators.msgSenderParam;
       node._newASTPointer.msgSenderParam ??= state.msgSenderParam;
 
-      const initialiseOrchestrationBoilerplateNodes = (fnIndicator: FunctionDefinitionIndicator) => {
-        const newNodes: any = {};
-        const contractName = `${parent.name}Shield`;
-        newNodes.InitialiseKeysNode = buildNode('InitialiseKeys', {
-          contractName,
-          onChainKeyRegistry: fnIndicator.onChainKeyRegistry,
-        });
-        if (fnIndicator.oldCommitmentAccessRequired || fnIndicator.internalFunctionoldCommitmentAccessRequired)
-          newNodes.initialisePreimageNode = buildNode('InitialisePreimage');
-        newNodes.readPreimageNode = buildNode('ReadPreimage', {
-          contractName,
-        });
-        if (fnIndicator.nullifiersRequired || fnIndicator.containsAccessedOnlyState || fnIndicator.internalFunctionInteractsWithSecret ) {
-          newNodes.membershipWitnessNode = buildNode('MembershipWitness', {
-            contractName,
-          });
-          newNodes.calculateNullifierNode = buildNode('CalculateNullifier');
-        }
-        if (fnIndicator.newCommitmentsRequired || fnIndicator.internalFunctionInteractsWithSecret)
-          newNodes.calculateCommitmentNode = buildNode('CalculateCommitment');
-          newNodes.generateProofNode = buildNode('GenerateProof', {
-          circuitName: node.fileName,
-        });
-        newNodes.sendTransactionNode = buildNode('SendTransaction', {
-          functionName: node.fileName,
-          contractName,
-        });
-        newNodes.writePreimageNode = buildNode('WritePreimage', {
-          contractName,
-          onChainKeyRegistry: fnIndicator.onChainKeyRegistry,
-        });
-        return newNodes;
-}
+
       // By this point, we've added a corresponding FunctionDefinition node to the newAST, with the same nodes as the original Solidity function, with some renaming here and there, and stripping out unused data from the oldAST.
       const functionIndicator: FunctionDefinitionIndicator = scope.indicators;
       for(const [, indicators ] of Object.entries(functionIndicator)){
@@ -373,7 +341,8 @@ const visitor = {
         functionIndicator.internalFunctionInteractsWithSecret) {
 
         const newNodes = initialiseOrchestrationBoilerplateNodes(
-          functionIndicator, 
+          functionIndicator,
+          path 
         );
 
         if (state.msgSenderParam) {

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -336,7 +336,7 @@ const visitor = {
           onChainKeyRegistry: fnIndicator.onChainKeyRegistry,
         });
         return newNodes;
-
+}
       // By this point, we've added a corresponding FunctionDefinition node to the newAST, with the same nodes as the original Solidity function, with some renaming here and there, and stripping out unused data from the oldAST.
       const functionIndicator: FunctionDefinitionIndicator = scope.indicators;
       for(const [, indicators ] of Object.entries(functionIndicator)){
@@ -373,7 +373,7 @@ const visitor = {
         functionIndicator.internalFunctionInteractsWithSecret) {
 
         const newNodes = initialiseOrchestrationBoilerplateNodes(
-          functionIndicator, path
+          functionIndicator, 
         );
 
         if (state.msgSenderParam) {

--- a/src/traverse/Indicator.ts
+++ b/src/traverse/Indicator.ts
@@ -76,6 +76,7 @@ export class FunctionDefinitionIndicator extends ContractDefinitionIndicator {
   interactsWithPublic?: boolean;
   internalFunctionInteractsWithSecret?: boolean;
   internalFunctionModifiesSecretState?: boolean;
+  internalFunctionoldCommitmentAccessRequired?: boolean;
   onChainKeyRegistry?: boolean;
 
   constructor(scope: Scope) {

--- a/test/contracts/internalFunctionCallTest1.zol
+++ b/test/contracts/internalFunctionCallTest1.zol
@@ -8,10 +8,10 @@ contract Assign {
 
   function remove(secret uint256 value) public {
     a -= value;
-    add(value);
+    add(value); // no  oldCommitmentAccessRequired but the contract does for function remove
   }
   function add(secret uint256 value) public {
-    known a = a + 2 * value;
+    unknown a = a + 2 * value;
   }
 
 

--- a/test/contracts/internalFunctionCallTest1.zol
+++ b/test/contracts/internalFunctionCallTest1.zol
@@ -6,12 +6,13 @@ contract Assign {
 
   secret uint256 private a;
 
+
   function remove(secret uint256 value) public {
     a -= value;
     add(value); // no  oldCommitmentAccessRequired but the contract does for function remove
   }
   function add(secret uint256 value) public {
-    unknown a = a + 2 * value;
+    known a = a + 2 * value;
   }
 
 

--- a/test/contracts/internalFunctionCallTest2.zol
+++ b/test/contracts/internalFunctionCallTest2.zol
@@ -16,7 +16,7 @@ contract Assign {
     known a += value;
   }
   function remove( uint256 value, uint256 value1 ) public {
-    known b += value;
+    unknown b += value;
     addB( value, value1);
     addA(value1);
   }

--- a/test/contracts/internalFunctionCallTest3.zol
+++ b/test/contracts/internalFunctionCallTest3.zol
@@ -8,7 +8,7 @@ contract Assign {
   secret uint256 private b;
 
   function addB(secret uint256 value) public {
-    known b += value;
+    unknown b += value;
 
   }
 

--- a/test/contracts/internalFunctionTest4.zol
+++ b/test/contracts/internalFunctionTest4.zol
@@ -4,7 +4,7 @@ contract Assign {
   secret uint256 private a;
   secret uint256 private b;
   function addB(secret uint256 value) public {
-    known b += value;
+    unknown b += value;
   }
 
 


### PR DESCRIPTION
this issue fixes the oldCommitmentAccess 'bug'
We were using `oldCommitmentAccessRequired` indictor in the internal function call here [https://github.com/EYBlockchain/starlight/pull/134/files#diff-a52c2fdc3e0665a750dc6d0f4ca6ba49b061393d4dc0d4baae37885da0afd6b8R309](url)
But that shouldn't work if the internal call doesn't need old commitment access but the contract does elsewhere. However it does work .
The issue is to fix the` oldCommitmentAccessRequired` indictor for contracts and then used `internalFunctionoldCommitmentAccessRequired ` 
