### PR TITLE
fix: update package-lock and add ts to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "json-diff": "^0.7.2",
         "json-diff-ts": "^1.2.4",
         "lodash.clonedeep": "^4.5.0",
-        "solc": "0.8.0",
+        "solc": "^0.8.0",
+        "typescript": "^4.2.3",
         "winston": "^3.3.3",
         "yargs": "^15.4.1",
         "zkp-utils": "^1.0.8"
@@ -6574,9 +6575,7 @@
     },
     "node_modules/typescript": {
       "version": "4.2.3",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11419,9 +11418,7 @@
       "version": "0.8.1"
     },
     "typescript": {
-      "version": "4.2.3",
-      "dev": true,
-      "peer": true
+      "version": "4.2.3"
     },
     "unbox-primitive": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "json-diff-ts": "^1.2.4",
     "lodash.clonedeep": "^4.5.0",
     "solc": "^0.8.0",
+    "typescript": "^4.2.3",
     "winston": "^3.3.3",
     "yargs": "^15.4.1",
     "zkp-utils": "^1.0.8"


### PR DESCRIPTION
Quick fix to add typescript to package.json and update the lock file.
I think we had it installed globally, so we never noticed that it wasn't in the repo...!