### PR TITLE
Fix: Upgrade ganache and constructor keys

### DIFF
--- a/src/boilerplate/common/boilerplate-docker-compose.yml
+++ b/src/boilerplate/common/boilerplate-docker-compose.yml
@@ -84,8 +84,8 @@ services:
       - zapp_network
 
   ganache:
-    image: trufflesuite/ganache-cli:latest
-    command: ganache-cli --accounts=10 --defaultBalanceEther=1000 --gasLimit=100000000 --deterministic
+    image: trufflesuite/ganache:v7.4.4
+    command: --accounts=10 --gasLimit=100000000 --deterministic
     ports:
       - '8545:8545'
     networks:

--- a/src/boilerplate/common/truffle-config.js
+++ b/src/boilerplate/common/truffle-config.js
@@ -46,6 +46,7 @@ module.exports = {
       host: 'ganache', // Localhost (default: none)
       port: 8545, // Standard Ethereum port (default: none)
       network_id: '*', // Any network (default: none)
+      gas: 10000000,
     },
     // localhost: {
     //   host: 'localhost', // Localhost (default: none)

--- a/src/traverse/Indicator.ts
+++ b/src/traverse/Indicator.ts
@@ -522,6 +522,12 @@ export class StateVariableIndicator extends FunctionDefinitionIndicator {
     this.owner ??= this.binding.owner;
     this.onChainKeyRegistry ??= this.binding.onChainKeyRegistry;
     this.parentIndicator.onChainKeyRegistry ??= this.binding.onChainKeyRegistry;
+
+    const functionType = this.scope.path.node.kind;
+     if (functionType === 'constructor') {
+         this.onChainKeyRegistry = false;
+         this.parentIndicator.onChainKeyRegistry = false;
+     }
     if (this.isMapping) {
       this.mappingOwnershipType = this.owner?.mappingOwnershipType;
       const mappingKeys: [string, MappingKey][] = Object.entries(this.mappingKeys);


### PR DESCRIPTION
This PR upgrades the old `ganache-cli` container to the newest version of `ganache` to avoid out of memory errors when dealing with large contracts (most commonly those needing a proof in the constructor).
The issue was intermittent so this will not be the easiest fix to test, however it no longer appears for me, and there should be no harm in upgrading.
I also brought over the fix currently in `miranda/encryption` which ensures that constructor functions do not attempt to register public keys with a contract that doesn't yet exist!
Closes #147 