### PR TITLE
Possible fix for global custom inputs

### DIFF
--- a/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
@@ -96,9 +96,9 @@ class FunctionBoilerplateGenerator {
           const names = structDef.members.map((mem: any) => {
             return { name: `${node.name}.${mem.name}`, type: mem.typeName.name };
           });
-          return { structName: structDef.name, properties: names };
+          return { structName: structDef.name, properties: names, isParam: path.isFunctionParameter(node) };
         }
-        return { name: node.name, type: node.typeName.name };
+        return { name: node.name, type: node.typeName.name, isParam: path.isFunctionParameter(node) };
       }
 
       const params = path.getFunctionParameters();

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -60,7 +60,7 @@ class FunctionBoilerplateGenerator {
     }): string[] {
       // prettier-ignore
       let parameter = [
-      ...(customInputs ? customInputs.filter(input => !input.dummy).filter(input => !!input.type).map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
+      ...(customInputs ? customInputs.filter(input => !input.dummy && input.isParam).map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
       ...(newNullifiers ? [`uint256[]`] : []),
       ...(commitmentRoot ? [`uint256`] : []),
       ...(newCommitments ? [`uint256[]`] : []),


### PR DESCRIPTION
Quick fix for global custom inputs sometimes appearing in the function signature string, causing errors in verification.

Hari's fix works as well, though I'm not sure if we have genuine cases where the custom input always have a type field when they are parameters, so this fix is just to cover all cases.