### PR TITLE
Mongo db for each zApp

### DIFF
--- a/src/boilerplate/common/boilerplate-docker-compose.yml
+++ b/src/boilerplate/common/boilerplate-docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - zokrates
       - timber
       - ganache
+      - zapp-mongo
     volumes:
       - ./build:/app/build
       - ./contracts/:/app/contracts/
@@ -26,6 +27,11 @@ services:
       BLOCKCHAIN_HOST: ws://ganache
       BLOCKCHAIN_PORT: 8545
       LOG_LEVEL: info
+      MONGO_HOST: mongodb://zapp-mongo
+      MONGO_PORT: 27019
+      MONGO_NAME: zapp_db
+      MONGO_USERNAME: admin
+      MONGO_PASSWORD: admin
     networks:
       - zapp_network
 
@@ -85,6 +91,21 @@ services:
     networks:
       - zapp_network
 
+    #The database storing commitments
+  zapp-mongo:
+    build:
+      context: .
+      dockerfile: Dockerfile.mongo
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=admin
+      - MONGO_INITDB_DATABASE=zapp_db
+    volumes:
+      - zapp-commitment-volume:/data/db
+    networks:
+      - zapp_network
+
+  
   ganache:
     image: trufflesuite/ganache:v7.4.4
     command: --accounts=10 --gasLimit=100000000 --deterministic
@@ -113,6 +134,7 @@ services:
 
 volumes:
   timber-mongo-volume: {}
+  zapp-commitment-volume: {}
 
 networks:
   zapp_network:

--- a/src/boilerplate/common/boilerplate-package.json
+++ b/src/boilerplate/common/boilerplate-package.json
@@ -27,6 +27,7 @@
     "enquirer": "^2.3.6",
     "general-number": "^1.0.1",
     "lodash.clonedeep": "^4.5.0",
+    "mongodb": "^4.7.0",
     "solc": "0.8.0",
     "truffle": "5.1.65",
     "web3": "^1.2.11",

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -25,19 +25,13 @@ export async function storeCommitment(commitment) {
     BigInt(commitment.preimage.salt.hex(32)),
   ]) : '';
   const preimage = generalise(commitment.preimage).all.hex(32);
-  preimage.value = commitment.preimage.value.integer;
+  preimage.value = generalise(commitment.preimage.value).all ? generalise(commitment.preimage.value).all.integer : generalise(commitment.preimage.value).integer;
   const data = {
     _id: commitment.hash.hex(32),
-	secretKey: commitment.secretKey.hex(32),
-    // compressedZkpPublicKey: commitment.compressedZkpPublicKey.hex(32),
+	secretKey: commitment.secretKey? commitment.secretKey.hex(32) : null,
     preimage,
-    // isDeposited: commitment.isDeposited || false,
-    // isOnChain: Number(commitment.isOnChain) || -1,
-    // isPendingNullification: false, // will not be pending when stored
     isNullified: commitment.isNullified,
-    // isNullifiedOnChain: Number(commitment.isNullifiedOnChain) || -1,
-    nullifier: nullifierHash.hex(32),
-    // blockNumber: -1,
+    nullifier: commitment.secretKey? nullifierHash.hex(32) : null,
   };
   logger.debug(`Storing commitment ${data._id}`);
   return db.collection(COMMITMENTS_COLLECTION).insertOne(data);

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -1,0 +1,318 @@
+/* eslint-disable import/no-cycle */
+/**
+Logic for storing and retrieving commitments from a mongo DB.
+*/
+import config from 'config';
+import gen from 'general-number';
+import mongo from './mongo.mjs';
+import logger from './logger.mjs';
+import utils from "zkp-utils";
+import { poseidonHash } from './number-theory.mjs';
+import { generateProof } from './zokrates.mjs';
+
+
+const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION } = config;
+const { generalise } = gen;
+
+// function to format a commitment for a mongo db and store it
+export async function storeCommitment(commitment) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  // we'll also compute and store the nullifier hash.
+  const nullifierHash = commitment.secretKey ? poseidonHash([
+    BigInt(commitment.preimage.stateVarId.hex(32)),
+    BigInt(commitment.secretKey.hex(32)),
+    BigInt(commitment.preimage.salt.hex(32)),
+  ]) : '';
+  const preimage = generalise(commitment.preimage).all.hex(32);
+  preimage.value = commitment.preimage.value.integer;
+  const data = {
+    _id: commitment.hash.hex(32),
+	secretKey: commitment.secretKey.hex(32),
+    // compressedZkpPublicKey: commitment.compressedZkpPublicKey.hex(32),
+    preimage,
+    // isDeposited: commitment.isDeposited || false,
+    // isOnChain: Number(commitment.isOnChain) || -1,
+    // isPendingNullification: false, // will not be pending when stored
+    isNullified: commitment.isNullified,
+    // isNullifiedOnChain: Number(commitment.isNullifiedOnChain) || -1,
+    nullifier: nullifierHash.hex(32),
+    // blockNumber: -1,
+  };
+  logger.debug(`Storing commitment ${data._id}`);
+  return db.collection(COMMITMENTS_COLLECTION).insertOne(data);
+}
+
+// function to retrieve commitment with a specified stateVarId
+export async function getCommitmentsById(id) {
+	const connection = await mongo.connection(MONGO_URL);
+	const db = connection.db(COMMITMENTS_DB);
+	const commitments = await db
+	  .collection(COMMITMENTS_COLLECTION)
+	  .find({ 'preimage.stateVarId': generalise(id).hex(32) })
+	  .toArray();
+	return commitments;
+  }
+
+// function to retrieve commitment with a specified stateVarId
+export async function getCurrentWholeCommitment(id) {
+	const connection = await mongo.connection(MONGO_URL);
+	const db = connection.db(COMMITMENTS_DB);
+	const commitment = await db
+	  .collection(COMMITMENTS_COLLECTION)
+	  .findOne({ 'preimage.stateVarId': generalise(id).hex(32), isNullified: false });
+	return commitment;
+  }
+
+/**
+ * @returns all the commitments existent in this database.
+ */
+ export async function getAllCommitments() {
+	const connection = await mongo.connection(MONGO_URL);
+	const db = connection.db(COMMITMENTS_DB);
+	const allCommitments = await db.collection(COMMITMENTS_COLLECTION).find().toArray();
+	return allCommitments;
+  }
+
+
+// function to update an existing commitment
+export async function updateCommitment(commitment, updates) {
+  const connection = await mongo.connection(MONGO_URL);
+  const db = connection.db(COMMITMENTS_DB);
+  const query = { _id: commitment._id };
+  const update = { $set: updates };
+  return db.collection(COMMITMENTS_COLLECTION).updateOne(query, update);
+}
+
+// function to mark a commitment as nullified for a mongo db
+export async function markNullified(commitmentHash, secretKey = null) {
+    const connection = await mongo.connection(MONGO_URL);
+	const db = connection.db(COMMITMENTS_DB);
+    const query = { _id: commitmentHash.hex(32) };
+	const commitment = await db
+	.collection(COMMITMENTS_COLLECTION)
+	.findOne(query);
+	const nullifier = poseidonHash([
+		BigInt(commitment.preimage.stateVarId),
+		BigInt(commitment.secretKey || secretKey),
+		BigInt(commitment.preimage.salt),
+	  ])
+    const update = {
+      $set: {
+        isNullified: true,
+		nullifier: generalise(nullifier).hex(32),
+      },
+    };
+    return db.collection(COMMITMENTS_COLLECTION).updateOne(query, update);
+  }
+
+
+export function getInputCommitments(
+	publicKey,
+	value,
+	commitments,
+	isStruct = false
+) {
+	
+	const possibleCommitments = commitments.filter(
+		(entry) => entry.preimage.publicKey === publicKey && !entry.isNullified
+	);
+	if (isStruct) {
+		let possibleCommitmentsProp = [];
+		value.forEach((propValue, i) => {
+			possibleCommitments.sort(
+				(commitA, commitB) =>
+					parseInt(Object.values(commitB.preimage.value)[i], 10) -
+					parseInt(Object.values(commitA.preimage.value)[i], 10)
+			);
+			if (
+				parseInt(Object.values(possibleCommitments[0].preimage.value)[i], 10) +
+					parseInt(Object.values(possibleCommitments[1].preimage.value)[i], 10) >=
+				parseInt(propValue, 10)
+			) {
+				possibleCommitmentsProp.push([
+					possibleCommitments[0],
+					possibleCommitments[1],
+				]);
+			}
+		});
+		const possibleCommitmentsSet = [
+			...new Set(
+				possibleCommitmentsProp
+					.flat(Infinity)
+					.filter(
+						(item, index) =>
+							possibleCommitmentsProp.flat(Infinity).indexOf(item) !== index
+					)
+			),
+		];
+		if (possibleCommitmentsSet.length >= 2) return possibleCommitmentsSet;
+		return null;
+	}
+	possibleCommitments.sort(
+		(commitA, commitB) =>
+			parseInt(commitB.preimage.value, 10) - parseInt(commitA.preimage.value, 10)
+	);
+	var commitmentsSum = 0;
+	possibleCommitments.forEach(commit => {
+		commitmentsSum += parseInt(commit.preimage.value, 10);
+	});
+	if (
+		parseInt(possibleCommitments[0].preimage.value, 10) +
+			parseInt(possibleCommitments[1].preimage.value, 10) >=
+		parseInt(value, 10)
+	) {
+		return [true, possibleCommitments[0], possibleCommitments[1]];
+	} else if (commitmentsSum >= parseInt(value, 10))
+		return [false, possibleCommitments[0], possibleCommitments[1]];
+	return null;
+}
+export async function joinCommitments(
+	contractName,
+	statename,
+	secretKey,
+	publicKey,
+	stateVarId,
+	commitments,
+	witnesses,
+	instance
+) {
+	logger.warn(
+		"Existing Commitments are not appropriate and we need to call Join Commitment Circuit. It will generate proof to join commitments, this will require an on-chain verification"
+	);
+
+
+	const oldCommitment_0_prevSalt = generalise(
+		commitments[0].preimage.salt
+	);
+	const oldCommitment_1_prevSalt = generalise(
+		commitments[1].preimage.salt
+	);
+	const oldCommitment_0_prev = generalise(commitments[0].preimage.value);
+	const oldCommitment_1_prev = generalise(commitments[1].preimage.value);
+
+	// Extract set membership witness:
+
+	const oldCommitment_0_witness = witnesses[0];
+	const oldCommitment_1_witness = witnesses[1];
+
+	const oldCommitment_0_index = generalise(oldCommitment_0_witness.index);
+	const oldCommitment_1_index = generalise(oldCommitment_1_witness.index);
+	const oldCommitment_root = generalise(oldCommitment_0_witness.root);
+	const oldCommitment_0_path = generalise(oldCommitment_0_witness.path).all;
+	const oldCommitment_1_path = generalise(oldCommitment_1_witness.path).all;
+
+	// increment would go here but has been filtered out
+
+	// Calculate nullifier(s):
+
+	let oldCommitment_stateVarId = stateVarId[0];
+	if (stateVarId.length > 1) {
+		oldCommitment_stateVarId = generalise(
+			utils.mimcHash(
+				[generalise(stateVarId[0]).bigInt, generalise(stateVarId[1]).bigInt],
+				"ALT_BN_254"
+			)
+		).hex(32);
+	}
+
+	let oldCommitment_0_nullifier = poseidonHash([
+		BigInt(oldCommitment_stateVarId),
+		BigInt(secretKey.hex(32)),
+		BigInt(oldCommitment_0_prevSalt.hex(32)),
+	]);
+	let oldCommitment_1_nullifier = poseidonHash([
+		BigInt(oldCommitment_stateVarId),
+		BigInt(secretKey.hex(32)),
+		BigInt(oldCommitment_1_prevSalt.hex(32)),
+	]);
+	oldCommitment_0_nullifier = generalise(oldCommitment_0_nullifier.hex(32)); // truncate
+	oldCommitment_1_nullifier = generalise(oldCommitment_1_nullifier.hex(32)); // truncate
+
+	// Calculate commitment(s):
+
+	const newCommitment_newSalt = generalise(utils.randomHex(31));
+
+	let newCommitment_value =
+		parseInt(oldCommitment_0_prev.integer, 10) +
+		parseInt(oldCommitment_1_prev.integer, 10);
+
+	newCommitment_value = generalise(newCommitment_value);
+
+	let newCommitment = poseidonHash([
+		BigInt(oldCommitment_stateVarId),
+		BigInt(newCommitment_value.hex(32)),
+		BigInt(publicKey.hex(32)),
+		BigInt(newCommitment_newSalt.hex(32)),
+	]);
+
+	newCommitment = generalise(newCommitment.hex(32)); // truncate
+
+	let stateVarID = parseInt(oldCommitment_stateVarId, 16);
+	let fromID = 0;
+	let isMapping = 0;
+	if (stateVarId.length > 1) {
+		stateVarID = stateVarId[0];
+		fromID = stateVarId[1].integer;
+		isMapping = 1;
+	}
+
+	// Call Zokrates to generate the proof:
+	const allInputs = [
+		fromID,
+		stateVarID,
+		isMapping,
+		secretKey.integer,
+		secretKey.integer,
+		oldCommitment_0_nullifier.integer,
+		oldCommitment_1_nullifier.integer,
+		oldCommitment_0_prev.integer,
+		oldCommitment_0_prevSalt.integer,
+		oldCommitment_1_prev.integer,
+		oldCommitment_1_prevSalt.integer,
+		oldCommitment_root.integer,
+		oldCommitment_0_index.integer,
+		oldCommitment_0_path.integer,
+		oldCommitment_1_index.integer,
+		oldCommitment_1_path.integer,
+		publicKey.integer,
+		newCommitment_newSalt.integer,
+		newCommitment.integer,
+	].flat(Infinity);
+
+	const res = await generateProof("joinCommitments", allInputs);
+	const proof = generalise(Object.values(res.proof).flat(Infinity))
+		.map((coeff) => coeff.integer)
+		.flat(Infinity);
+
+	// Send transaction to the blockchain:
+
+	const tx = await instance.methods
+		.joinCommitments(
+			[oldCommitment_0_nullifier.integer, oldCommitment_1_nullifier.integer],
+			oldCommitment_root.integer,
+			[newCommitment.integer],
+			proof
+		)
+		.send({
+			from: config.web3.options.defaultAccount,
+			gas: config.web3.options.defaultGas,
+		});
+
+	
+	await markNullified(generalise(commitments[0]._id), secretKey.hex(32));
+	await markNullified(generalise(commitments[1]._id), secretKey.hex(32));
+	await storeCommitment({
+		hash: newCommitment,
+		preimage: {
+			stateVarId: generalise(stateVarID),
+			value: newCommitment_value,
+			salt: newCommitment_newSalt,
+			publicKey: publicKey,
+		},
+		secretKey: secretKey,
+		isNullified: false,
+	});
+
+	return { tx };
+}

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -28,6 +28,8 @@ export async function storeCommitment(commitment) {
   preimage.value = generalise(commitment.preimage.value).all ? generalise(commitment.preimage.value).all.integer : generalise(commitment.preimage.value).integer;
   const data = {
     _id: commitment.hash.hex(32),
+	name: commitment.name,
+	mappingKey: commitment.mappingKey ? commitment.mappingKey : null,
 	secretKey: commitment.secretKey? commitment.secretKey.hex(32) : null,
     preimage,
     isNullified: commitment.isNullified,
@@ -57,6 +59,19 @@ export async function getCurrentWholeCommitment(id) {
 	  .findOne({ 'preimage.stateVarId': generalise(id).hex(32), isNullified: false });
 	return commitment;
   }
+
+// function to retrieve commitment with a specified stateName
+export async function getCommitmentsByState(name, mappingKey = null) {
+	const connection = await mongo.connection(MONGO_URL);
+	const db = connection.db(COMMITMENTS_DB);
+	const query = { 'name': name };
+	if (mappingKey) query['mappingKey'] = generalise(mappingKey).integer;
+	const commitments = await db
+		.collection(COMMITMENTS_COLLECTION)
+		.find(query)
+		.toArray();
+	return commitments;
+}
 
 /**
  * @returns all the commitments existent in this database.

--- a/src/boilerplate/common/config/default.js
+++ b/src/boilerplate/common/config/default.js
@@ -78,6 +78,9 @@ module.exports = {
     admin: 'admin',
     adminPassword: 'admin',
   },
+  MONGO_URL: 'mongodb://admin:admin@zapp-mongo:27017',
+  COMMITMENTS_DB: process.env.MONGO_NAME,
+  COMMITMENTS_COLLECTION: 'commitments',
   isLoggerEnabled: true,
   // web3:
   deployer: {

--- a/src/boilerplate/common/contract.mjs
+++ b/src/boilerplate/common/contract.mjs
@@ -1,449 +1,149 @@
 import fs from 'fs';
 import config from 'config';
-import pkg from 'general-number';
+import GN from 'general-number';
 import utils from 'zkp-utils';
 import Web3 from './web3.mjs';
 import logger from './logger.mjs';
-import { generateProof } from './zokrates.mjs';
-import { scalarMult, compressStarlightKey, poseidonHash } from './number-theory.mjs';
+
+import {
+	scalarMult,
+	compressStarlightKey,
+	poseidonHash,
+} from './number-theory.mjs';
 
 const web3 = Web3.connection();
-const { generalise, GN } = pkg;
-const db = '/app/orchestration/common/db/preimage.json';
+const { generalise } = GN;
 const keyDb = '/app/orchestration/common/db/key.json';
 
-export const contractPath = contractName => {
-  return `/app/build/contracts/${contractName}.json`;
+export const contractPath = (contractName) => {
+	return `/app/build/contracts/${contractName}.json`;
 };
 
 const { options } = config.web3;
 
 export async function getContractInterface(contractName) {
-  const path = contractPath(contractName);
+	const path = contractPath(contractName);
   const contractInterface = JSON.parse(fs.readFileSync(path, 'utf8'));
-  // logger.debug('\ncontractInterface:', contractInterface);
-  return contractInterface;
+	// logger.debug('\ncontractInterface:', contractInterface);
+	return contractInterface;
 }
 
 export async function getContractAddress(contractName) {
-  let deployedAddress;
-  let errorCount = 0;
+	let deployedAddress;
+	let errorCount = 0;
 
-  if (!deployedAddress) {
-    while (errorCount < 25) {
-      try {
-        const contractInterface = await getContractInterface(contractName);
-        const networkId = await web3.eth.net.getId();
+	if (!deployedAddress) {
+		while (errorCount < 25) {
+			try {
+				const contractInterface = await getContractInterface(contractName);
+				const networkId = await web3.eth.net.getId();
         logger.silly('networkId:', networkId);
 
-        if (
-          contractInterface &&
-          contractInterface.networks &&
-          contractInterface.networks[networkId]
-        ) {
-          deployedAddress = contractInterface.networks[networkId].address;
-        }
+				if (
+					contractInterface &&
+					contractInterface.networks &&
+					contractInterface.networks[networkId]
+				) {
+					deployedAddress = contractInterface.networks[networkId].address;
+				}
         if (deployedAddress === undefined) throw new Error('Shield address was undefined');
-        if (deployedAddress) break;
-      } catch (err) {
-        errorCount++;
+				if (deployedAddress) break;
+			} catch (err) {
+				errorCount++;
         logger.warn('Unable to get a contract address - will try again in 5 seconds');
         await new Promise(resolve => setTimeout(() => resolve(), 5000));
-      }
-    }
-  }
+			}
+		}
+	}
 
   logger.silly('deployed address:', deployedAddress);
-  return deployedAddress;
+	return deployedAddress;
 }
 
 // returns a web3 contract instance
 export async function getContractInstance(contractName, deployedAddress) {
-  const contractInterface = await getContractInterface(contractName);
-  if (!deployedAddress) {
-    // eslint-disable-next-line no-param-reassign
-    deployedAddress = await getContractAddress(contractName);
-  }
+	const contractInterface = await getContractInterface(contractName);
+	if (!deployedAddress) {
+		// eslint-disable-next-line no-param-reassign
+		deployedAddress = await getContractAddress(contractName);
+	}
 
-  const contractInstance = deployedAddress
-    ? new web3.eth.Contract(contractInterface.abi, deployedAddress, options)
-    : new web3.eth.Contract(contractInterface.abi, null, options);
-  // logger.silly('\ncontractInstance:', contractInstance);
-  logger.info(`${contractName} Address: ${deployedAddress}`);
+	const contractInstance = deployedAddress
+		? new web3.eth.Contract(contractInterface.abi, deployedAddress, options)
+		: new web3.eth.Contract(contractInterface.abi, null, options);
+	// logger.silly('\ncontractInstance:', contractInstance);
+	logger.info(`${contractName} Address: ${deployedAddress}`);
 
-  return contractInstance;
+	return contractInstance;
 }
 
 export async function getContractBytecode(contractName) {
-  const contractInterface = await getContractInterface(contractName);
-  return contractInterface.evm.bytecode.object;
+	const contractInterface = await getContractInterface(contractName);
+	return contractInterface.evm.bytecode.object;
 }
 
-export async function deploy(userAddress, userAddressPassword, contractName, constructorParams) {
-  logger.info(`\nUnlocking account ${userAddress}...`);
-  await web3.eth.personal.unlockAccount(userAddress, userAddressPassword, 1);
+export async function deploy(
+	userAddress,
+	userAddressPassword,
+	contractName,
+	constructorParams
+) {
+	logger.info(`\nUnlocking account ${userAddress}...`);
+	await web3.eth.personal.unlockAccount(userAddress, userAddressPassword, 1);
 
-  const contractInstance = await getContractInstance(contractName); // get a web3 contract instance of the contract
-  const bytecode = await getContractBytecode(contractName);
+	const contractInstance = await getContractInstance(contractName); // get a web3 contract instance of the contract
+	const bytecode = await getContractBytecode(contractName);
 
-  const deployedContractAddress = await contractInstance
-    .deploy({ data: `0x${bytecode}`, arguments: constructorParams })
-    .send({
-      from: userAddress,
-      gas: config.web3.options.defaultGas,
-    })
+	const deployedContractAddress = await contractInstance
+		.deploy({ data: `0x${bytecode}`, arguments: constructorParams })
+		.send({
+			from: userAddress,
+			gas: config.web3.options.defaultGas,
+		})
     .on('error', err => {
-      throw new Error(err);
-    })
+			throw new Error(err);
+		})
     .then(deployedContractInstance => {
-      // logger.silly('deployed contract instance:', deployedContractInstance);
-      logger.info(
+			// logger.silly('deployed contract instance:', deployedContractInstance);
+			logger.info(
         `${contractName} contract deployed at address ${deployedContractInstance.options.address}`,
-      ); // instance with the new contract address
+			); // instance with the new contract address
 
-      return deployedContractInstance.options.address;
-    });
-  return deployedContractAddress;
+			return deployedContractInstance.options.address;
+		});
+	return deployedContractAddress;
 }
 
 export async function registerKey(
-  _secretKey,
-  contractName,
+	_secretKey,
+	contractName,
   registerWithContract,
 ) {
-  let secretKey = generalise(_secretKey);
-  let publicKeyPoint = generalise(
+	let secretKey = generalise(_secretKey);
+	let publicKeyPoint = generalise(
     scalarMult(secretKey.hex(32), config.BABYJUBJUB.GENERATOR),
-  );
-  let publicKey = compressStarlightKey(publicKeyPoint);
-  while (publicKey === null) {
-    logger.warn(`your secret key created a large public key - resetting`);
-    secretKey = generalise(utils.randomHex(31));
-    publicKeyPoint = generalise(
+	);
+	let publicKey = compressStarlightKey(publicKeyPoint);
+	while (publicKey === null) {
+		logger.warn(`your secret key created a large public key - resetting`);
+		secretKey = generalise(utils.randomHex(31));
+		publicKeyPoint = generalise(
       scalarMult(secretKey.hex(32), config.BABYJUBJUB.GENERATOR),
-    );
-    publicKey = compressStarlightKey(publicKeyPoint);
-  }
-  if (registerWithContract) {
-    const instance = await getContractInstance(contractName);
-    await instance.methods.registerZKPPublicKey(publicKey.integer).send({
-      from: config.web3.options.defaultAccount,
-      gas: config.web3.options.defaultGas,
-    });
-  }
-  const keyJson = {
-    secretKey: secretKey.integer,
-    publicKey: publicKey.integer, // not req
-  };
-  fs.writeFileSync(keyDb, JSON.stringify(keyJson, null, 4));
-
-  return publicKey;
-}
-
-function getStructInputCommitments(
-	value,
-	possibleCommitments
-) {
-	let possibleCommitmentsProp = [];
-	value.forEach((propValue, i) => {
-		let possibleCommitmentsTemp = [];
-		possibleCommitments.sort(
-			(preimageA, preimageB) =>
-				parseInt(Object.values(preimageB[1].value)[0], 10) -
-				parseInt(Object.values(preimageA[1].value)[0], 10)
 		);
-		if(possibleCommitmentsProp.length === 0){
-			if (
-					parseInt(Object.values(possibleCommitments[0][1].value)[i], 10) +
-						parseInt(Object.values(possibleCommitments[1][1].value)[i], 10) >
-					parseInt(propValue, 10)
-				) {
-					possibleCommitmentsProp.push([
-						possibleCommitments[0][0],
-						possibleCommitments[1][0],
-					]);
-				}
-		}
-		else {
-			possibleCommitmentsProp.forEach((commitment) => {
-				commitment.forEach((item) => {
-				 possibleCommitments.forEach((possibleCommit) => {
-					 if(item === possibleCommit[0]){
-						possibleCommitmentsTemp.push(possibleCommit)
-					 }
-				  });
-				})
-			})
-			if (
-					parseInt(Object.values(possibleCommitmentsTemp[0][1].value)[i], 10) +
-						parseInt(Object.values(possibleCommitmentsTemp[1][1].value)[i], 10) <
-					parseInt(propValue, 10)
-				) {
-					possibleCommitments.splice(0,2);
-				  possibleCommitmentsProp = getStructInputCommitments(value, possibleCommitments);
-			 }
-       else {
-         logger.warn('Enough Commitments dont exists to use.' )
-         return null;
-       }
-		}
-});
-return possibleCommitmentsProp;
-}
-
-// this fn is useful for checking decrypted values match some existing commitment
-// expecting search term in the form { key: value }
-export function searchPartitionedCommitments(commitmentSet, searchTerm) {
-  // for a mapping, we have commitments stored by:
-  // stateName.mappingKeyName.commitmentHash
-  let allCommitments = [];
-  const stateNames = Object.keys(commitmentSet);
-  stateNames.forEach((stateName) => {
-    if (Object.entries(commitmentSet[stateName])[0][1].salt) {
-      // isMapping = false;
-      allCommitments = allCommitments.concat(Object.values(commitmentSet[stateName]));
-    } else {
-      Object.keys(commitmentSet[stateName]).forEach(mappingKey => {
-        allCommitments = allCommitments.concat(
-          Object.values(commitmentSet[stateName][mappingKey]),
-        );
-      });
-    }
-  });
-  const [key, value] = Object.entries(searchTerm)[0];
-  let foundValue = false;
-  allCommitments.forEach(commitment => {
-    if (commitment[key] === generalise(value).integer) {
-			foundValue = true;
-		}
-  });
-  return foundValue;
-}
-
-export function getInputCommitments(publicKey, value, commitments, isStruct = false) {
-  const possibleCommitments = Object.entries(commitments).filter(
-    entry => entry[1].publicKey === publicKey && !entry[1].isNullified,
-  );
-  if (isStruct) {
-		let possibleCommitmentsProp = getStructInputCommitments(value, possibleCommitments);
-		if (
-			possibleCommitmentsProp.length > 0
-		)
-			return [possibleCommitmentsProp[0][0], possibleCommitmentsProp[0][1]];
-		return null;
+		publicKey = compressStarlightKey(publicKeyPoint);
 	}
-  possibleCommitments.sort(
-    (preimageA, preimageB) =>
-      parseInt(preimageB[1].value, 10) - parseInt(preimageA[1].value, 10),
-  );
-  var commitmentsSum = 0;
-  console.log('Commitment Sum:', commitmentsSum);
-	for (var i = 0; i < possibleCommitments.length; i++) {
-	  for (var j = 0 ;  j < possibleCommitments.length; j++){
-		 if(possibleCommitments[i][j] && possibleCommitments[i][j].value)
-		 commitmentsSum = commitmentsSum + parseInt(possibleCommitments[i][j].value, 10);
-	  }
+	if (registerWithContract) {
+		const instance = await getContractInstance(contractName);
+		await instance.methods.registerZKPPublicKey(publicKey.integer).send({
+			from: config.web3.options.defaultAccount,
+			gas: config.web3.options.defaultGas,
+		});
 	}
-  console.log('Commitment Sum:', commitmentsSum);
-  if (
-    parseInt(possibleCommitments[0][1].value, 10) +
-      parseInt(possibleCommitments[1][1].value, 10) >
-    parseInt(value, 10)
-  ) {
-    return [true, possibleCommitments[0][0], possibleCommitments[1][0]];
-  } else if(commitmentsSum >=   parseInt(value, 10))
-	 return  [false, possibleCommitments[0][0], possibleCommitments[1][0]];
-  return null;
-}
-  export async function joinCommitments(contractName, statename, secretKey, publicKey, stateVarId, commitments, commitmentsID, witnesses, instance, isStruct = false, structProperties = []){
+	const keyJson = {
+		secretKey: secretKey.integer,
+		publicKey: publicKey.integer, // not req
+	};
+	fs.writeFileSync(keyDb, JSON.stringify(keyJson, null, 4));
 
-  logger.warn('Existing Commitments are not appropriate and we need to call Join Commitment Circuit. It will generate proof to join commitments, this will require an on-chain verification');
-  const oldCommitment_0 = commitmentsID[0];
-
-	const oldCommitment_1 = commitmentsID[1];
-
-	const oldCommitment_0_prevSalt = generalise(commitments[oldCommitment_0].salt);
-	const oldCommitment_1_prevSalt = generalise(commitments[oldCommitment_1].salt);
-	const oldCommitment_0_prev = generalise(commitments[oldCommitment_0].value);
-	const oldCommitment_1_prev = generalise(commitments[oldCommitment_1].value);
-
-	// Extract set membership witness:
-
-	const oldCommitment_0_witness = witnesses[0];
-	const oldCommitment_1_witness = witnesses[1];
-
-
-	const oldCommitment_0_index = generalise(oldCommitment_0_witness.index);
-	const oldCommitment_1_index = generalise(oldCommitment_1_witness.index);
-	const oldCommitment_root = generalise(oldCommitment_0_witness.root);
-	const oldCommitment_0_path = generalise(oldCommitment_0_witness.path).all;
-	const oldCommitment_1_path = generalise(oldCommitment_1_witness.path).all;
-
-	// increment would go here but has been filtered out
-
-	// Calculate nullifier(s):
-
-   let oldCommitment_stateVarId = stateVarId[0];
-   if(stateVarId.length > 1){
-       oldCommitment_stateVarId =  generalise(
-         utils.mimcHash(
-           [
-             generalise(stateVarId[0]).bigInt,
-             generalise(stateVarId[1]).bigInt,
-           ],
-           "ALT_BN_254"
-         )
-       ).hex(32);
-     }
-
-
-
-	let oldCommitment_0_nullifier = poseidonHash([
-		BigInt(oldCommitment_stateVarId), BigInt(secretKey.hex(32)), BigInt(oldCommitment_0_prevSalt.hex(32))
-  ],);
-	let oldCommitment_1_nullifier = poseidonHash([
-		BigInt(oldCommitment_stateVarId), BigInt(secretKey.hex(32)), BigInt(oldCommitment_1_prevSalt.hex(32))
-  ],);
-	oldCommitment_0_nullifier = generalise(oldCommitment_0_nullifier.hex(32)); // truncate
-	oldCommitment_1_nullifier = generalise(oldCommitment_1_nullifier.hex(32)); // truncate
-
-	// Calculate commitment(s):
-
-	const newCommitment_newSalt = generalise(utils.randomHex(32));
-
-  let newCommitment_value = [];
-  let oldCommitment_0_value = [];
-  let oldCommitment_1_value = [];
-  let newCommitment;
-
-  if(structProperties){
-    Object.keys(oldCommitment_0_prev).forEach(
-				(p, i) => oldCommitment_0_value[i] = parseInt(oldCommitment_0_prev[p].integer, 10));
-
-    Object.keys(oldCommitment_1_prev).forEach(
-				(p, i) => oldCommitment_1_value[i] = parseInt(oldCommitment_1_prev[p].integer, 10));
-
-    Object.keys(oldCommitment_0_prev).forEach(
-				(p, i) =>
-				newCommitment_value[i] = parseInt(oldCommitment_0_prev[p].integer, 10) +
-					parseInt(oldCommitment_1_prev[p].integer, 10)
-		  );
-    newCommitment_value = generalise(newCommitment_value).all;
-
-     newCommitment = poseidonHash([
-  		BigInt(oldCommitment_stateVarId),
-  		...newCommitment_value.hex(32).map((v) => BigInt(v)),
-  		BigInt(publicKey.hex(32)),
-  		BigInt(newCommitment_newSalt.hex(32)),
-  	]);
-  } else{
-
-    oldCommitment_0_value = parseInt(oldCommitment_0_prev.integer, 10) ;
-    oldCommitment_1_value = parseInt(oldCommitment_1_prev.integer, 10) ;
-
-    newCommitment_value = parseInt(oldCommitment_0_prev.integer, 10) +
-      parseInt(oldCommitment_1_prev.integer, 10);
-
-  	newCommitment_value = generalise(newCommitment_value);
-
-     newCommitment = poseidonHash([
-  			BigInt(oldCommitment_stateVarId),
-  			BigInt(newCommitment_value.hex(32)),
-  			BigInt(publicKey.hex(32)),
-  			BigInt(newCommitment_newSalt.hex(32))
-    ]);
-  }
-
-	newCommitment = generalise(newCommitment.hex(32)); // truncate
-
-  let stateVarID = parseInt(oldCommitment_stateVarId,16);
-  let  fromID = 0;
-  let isMapping=0;
-  if(stateVarId.length > 1 ){
-    stateVarID  = stateVarId[0];
-    fromID = stateVarId[1].integer;;
-     isMapping = 1;
-  }
-
-
-// Call Zokrates to generate the proof:
-const allInputs = [
-fromID,
-stateVarID,
-isMapping,
-secretKey.limbs(32, 8),
-secretKey.limbs(32, 8),
-oldCommitment_0_nullifier.integer,
-oldCommitment_1_nullifier.integer,
-oldCommitment_0_value,
-oldCommitment_0_prevSalt.integer,
-oldCommitment_1_value,
-oldCommitment_1_prevSalt.integer,
-oldCommitment_root.integer,
-oldCommitment_0_index.integer,
-oldCommitment_0_path.integer,
-oldCommitment_1_index.integer,
-oldCommitment_1_path.integer,
-publicKey.integer,
-newCommitment_newSalt.integer,
-newCommitment.integer,
-].flat(Infinity);
-
-const res = await generateProof( "joinCommitments", allInputs);
-const proof = generalise(Object.values(res.proof).flat(Infinity))
-.map((coeff) => coeff.integer)
-.flat(Infinity);
-
-// Send transaction to the blockchain:
-
-const tx = await instance.methods
-.joinCommitments(
-  [oldCommitment_0_nullifier.integer, oldCommitment_1_nullifier.integer,],
-  oldCommitment_root.integer,
-  [newCommitment.integer],
-  proof
-).send({
-  from: config.web3.options.defaultAccount,
-  gas: config.web3.options.defaultGas,
-});
-
-      let preimage = {};
-      if (fs.existsSync(db)) {
-        preimage = JSON.parse(
-          fs.readFileSync(db, "utf-8", (err) => {
-            console.log(err);
-          })
-        );
-      }
-
-      Object.keys(preimage).forEach((key) => {
-    		if (key === statename) {
-    			preimage[key][oldCommitment_0].isNullified = true;
-    			preimage[key][oldCommitment_1].isNullified = true;
-    			preimage[key][newCommitment.hex(32)] = {
-    				value: newCommitment_value.integer,
-    				salt: newCommitment_newSalt.integer,
-    				publicKey: publicKey.integer,
-    				commitment: newCommitment.integer,
-    			}
-    		}
-
-    			else	if (key === statename.split('[')[0]){
-    					Object.keys(preimage[key]).forEach((id) => {
-    						if(parseInt(id,10) === parseInt(fromID,10)){
-    							preimage[key][id][oldCommitment_0].isNullified = true;
-    							preimage[key][id][oldCommitment_1].isNullified = true;
-    							preimage[key][id][newCommitment.hex(32)] = {
-    								value: newCommitment_value.integer,
-    								salt: newCommitment_newSalt.integer,
-    								publicKey: publicKey.integer,
-    								commitment: newCommitment.integer,
-    						}
-    					}
-    					})
-    				}
-    			fs.writeFileSync(db, JSON.stringify(preimage, null, 4));
-       });
-
-  return { tx };
+	return publicKey;
 }

--- a/src/boilerplate/common/mongo.mjs
+++ b/src/boilerplate/common/mongo.mjs
@@ -1,0 +1,42 @@
+
+
+/* eslint import/no-extraneous-dependencies: "off" */
+/* ignore unused exports */
+
+/**
+Mongo database functions
+*/
+
+import mongo from 'mongodb';
+
+const { MongoClient } = mongo;
+const connection = {};
+
+export default {
+  async connection(url) {
+    console.log(`connecting to mongo: ${url}`)
+    if (connection[url]) return connection[url];
+    // Check if we are connecting to MongoDb or DocumentDb
+    const { MONGO_CONNECTION_STRING = '' } = process.env;
+    if (MONGO_CONNECTION_STRING !== '') {
+      const client = await new MongoClient(`${MONGO_CONNECTION_STRING}`, {
+        useUnifiedTopology: true,
+      });
+      connection[url] = await client.connect();
+    } else {
+      const client = await new MongoClient(url, {
+        useUnifiedTopology: true,
+        connectTimeoutMS: 40000,
+        // keepAlive: true,
+        // serverSelectionTimeoutMS: 30000,
+        // socketTimeoutMS: 360000,
+      });
+      connection[url] = await client.connect();
+    }
+    return connection[url];
+  },
+  async disconnect(url) {
+    connection[url].close();
+    delete connection[url];
+  },
+};

--- a/src/boilerplate/common/services/generic-api_services.mjs
+++ b/src/boilerplate/common/services/generic-api_services.mjs
@@ -6,7 +6,7 @@ import { startEventFilter, getSiblingPath } from "./common/timber.mjs";
 import fs from "fs";
 import logger from "./common/logger.mjs";
 import { decrypt } from "./common/number-theory.mjs";
-import { searchPartitionedCommitments } from "./common/contract.mjs";
+import { getAllCommitments, getCommitmentsByState } from "./common/commitment-storage.mjs";
 import web3 from "./common/web3.mjs";
 
 /**

--- a/src/boilerplate/common/setup-admin-user.js
+++ b/src/boilerplate/common/setup-admin-user.js
@@ -5,5 +5,8 @@ this.db.createUser({
     { role: 'userAdmin', db: 'merkle_tree' },
     { role: 'dbAdmin', db: 'merkle_tree' },
     { role: 'readWrite', db: 'merkle_tree' },
+    { role: 'userAdmin', db: 'zapp_db' },
+    { role: 'dbAdmin', db: 'zapp_db' },
+    { role: 'readWrite', db: 'zapp_db' },
   ],
 });

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -131,12 +131,15 @@ class BoilerplateGenerator {
               \nlet ${stateName}_preimage = await getCommitmentsById(${stateName}_stateVarId);
               \nconst ${stateName}_newCommitmentValue = generalise([${Object.values(increment).map((inc) => `generalise(${inc})`)}]).all;
 
-              \nlet [commitmentFlag, ${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment] = getInputCommitments(
+              \nlet [${stateName}_commitmentFlag, ${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment] = getInputCommitments(
                 publicKey.hex(32),
                 ${stateName}_newCommitmentValue.integer,
                 ${stateName}_preimage,
                 true,
               );
+
+              \nlet ${stateName}_witness_0;
+              \nlet ${stateName}_witness_1;
 
               const ${stateName}_0_prevSalt = generalise(${stateName}_0_oldCommitment.preimage.salt);
               const ${stateName}_1_prevSalt = generalise(${stateName}_1_oldCommitment.preimage.salt);

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -525,7 +525,7 @@ integrationTestBoilerplate = {
         console.log(plainText);
         const salt = plainText[plainText.length - 1];
         const commitmentSet = await getAllCommitments();
-        const thisCommit = commitmentSet.find(c => generalise(c.preimage.salt).integer === generalise(salt.integer));
+        const thisCommit = commitmentSet.find(c => generalise(c.preimage.salt).integer === generalise(salt).integer);
         assert.equal(!!thisCommit, true);
 
       } catch (err) {
@@ -536,7 +536,7 @@ integrationTestBoilerplate = {
     `
   },
   preStatements(): string{
-    return ` import { startEventFilter, getSiblingPath } from './common/timber.mjs';\nimport fs from "fs";\nimport {getAllCommitments} from "./common/commitment-storage.mjs";\nimport logger from './common/logger.mjs';\nimport { decrypt } from "./common/number-theory.mjs";\nimport web3 from './common/web3.mjs';\n\n
+    return ` import { startEventFilter, getSiblingPath } from './common/timber.mjs';\nimport fs from "fs";\n import GN from "general-number";\nimport {getAllCommitments} from "./common/commitment-storage.mjs";\nimport logger from './common/logger.mjs';\nimport { decrypt } from "./common/number-theory.mjs";\nimport web3 from './common/web3.mjs';\n\n
         /**
       Welcome to your zApp's integration test!
       Depending on how your functions interact and the range of inputs they expect, the below may need to be changed.
@@ -547,6 +547,7 @@ integrationTestBoilerplate = {
       NOTE: if you'd like to keep track of your commitments, check out ./common/db/preimage. Remember to delete this file if you'd like to start fresh with a newly deployed contract.
       */
       const sleep = ms => new Promise(r => setTimeout(r, ms));
+      const { generalise } = GN;
       let leafIndex;
       let encryption = {};
       // eslint-disable-next-line func-names

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -563,7 +563,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
                     stateType: 'decrement',
                     mappingName: stateNode.mappingName || stateName,
                     mappingKey: stateNode.mappingKey
-                      ? `[${stateName}_stateVarId_key.integer]`
+                      ? `${stateName}_stateVarId_key.integer`
                       : ``,
                     burnedOnly: false,
                     structProperties: stateNode.structProperties,
@@ -578,7 +578,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
                     stateType: 'increment',
                     mappingName:stateNode.mappingName || stateName,
                     mappingKey: stateNode.mappingKey
-                      ? `[${stateName}_stateVarId_key.integer]`
+                      ? `${stateName}_stateVarId_key.integer`
                       : ``,
                     burnedOnly: false,
                     structProperties: stateNode.structProperties,
@@ -595,7 +595,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
                 stateType: 'whole',
                 mappingName: stateNode.mappingName || stateName,
                 mappingKey: stateNode.mappingKey
-                  ? `[${stateName}_stateVarId_key.integer]`
+                  ? `${stateName}_stateVarId_key.integer`
                   : ``,
                 burnedOnly: stateNode.burnedOnly,
                 structProperties: stateNode.structProperties,

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -572,15 +572,6 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
                 break;
               case false:
               default:
-                if (stateNode.mappingKey) {
-                  lines.push(`
-                  \nif (!preimage.${stateNode.mappingName}) preimage.${stateNode.mappingName} = {};
-                  \nif (!preimage.${stateNode.mappingName}[${stateName}_stateVarId_key.integer]) preimage.${stateNode.mappingName}[${stateName}_stateVarId_key.integer] = {};`);
-                } else {
-                  lines.push(`
-                  \nif (!preimage.${stateName}) preimage.${stateName} = {};`);
-                }
-
                 lines.push(
                     Orchestrationbp.writePreimage.postStatements({
                     stateName,
@@ -598,14 +589,6 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
             break;
           case false:
           default:
-            if (stateNode.mappingKey) {
-              lines.push(`
-              \nif (!preimage.${stateNode.mappingName}) preimage.${stateNode.mappingName} = {};
-              \nif (!preimage.${stateNode.mappingName}[${stateName}_stateVarId_key.integer]) preimage.${stateNode.mappingName}[${stateName}_stateVarId_key.integer] = {};`);
-            } else {
-              lines.push(`
-              \nif (!preimage.${stateName}) preimage.${stateName} = {};`);
-            }
             lines.push(
                 Orchestrationbp.writePreimage.postStatements({
                 stateName,
@@ -622,17 +605,8 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
       if (node.isConstructor) lines.push(`\nfs.writeFileSync("/app/orchestration/common/db/constructorTx.json", JSON.stringify(tx, null, 4));`)
       return {
         statements: [
-          `\n// Write new commitment preimage to db: \n
-          \nlet preimage = {};`,
-          `\nif (fs.existsSync(db)) {
-            preimage = JSON.parse(
-                fs.readFileSync(db, 'utf-8', err => {
-                  console.log(err);
-                }),
-              );
-            }`,
+          `\n// Write new commitment preimage to db: \n`,
           lines.join('\n'),
-          `\nfs.writeFileSync(db, JSON.stringify(preimage, null, 4));`,
         ],
       };
 

--- a/src/codeGenerators/orchestration/files/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/files/toOrchestration.ts
@@ -193,7 +193,7 @@ const prepareIntegrationApiServices = (node: any) => {
   });
   // add linting and config
   const preprefix = `/* eslint-disable prettier/prettier, camelcase, prefer-const, no-unused-vars */ \nimport config from 'config';\nimport assert from 'assert';\n`;
-  outputApiServiceFile = `${preprefix}\n${outputApiServiceFile}\n \n`;
+  outputApiServiceFile = `${preprefix}\n${outputApiServiceFile}\n ${genericApiServiceFile.commitments()}\n`;
   return outputApiServiceFile;
 };
 const prepareIntegrationApiRoutes = (node: any) => {
@@ -221,6 +221,9 @@ const prepareIntegrationApiRoutes = (node: any) => {
     outputApiRoutesimport = `${outputApiRoutesimport}\n${fnimport}\n`;
     outputApiRoutesboilerplate = `${outputApiRoutesboilerplate}\n${fnboilerplate}\n`
   });
+  // add getters for commitments
+  outputApiRoutesimport = `${outputApiRoutesimport}\n${genericApiRoutesFile.commitmentImports()}\n`;
+  outputApiRoutesboilerplate = `${outputApiRoutesboilerplate}\n${genericApiRoutesFile.commitmentRoutes()}\n`
   const fnprestatement = genericApiRoutesFile.preStatements();
   const postfix = `export default router;`;
   outputApiRoutesFile = `${outputApiRoutesimport}\n${fnprestatement}\n${outputApiRoutesboilerplate}\n ${postfix}`;


### PR DESCRIPTION
This PR adds a mongodb for commitment preimages (i.e. secret info - so this db should always be local) in output zApps.
Main changes:

- New boilerplate files `commitment-storage.mjs` to manage the db (store, extract, check, etc.) and `mongo.mjs` to connect to it
- New docker mongo service called `zapp-db` with separate login details to the timber mongo instance
- Changes to orchestration code in `readPreimage`, `initialisePreimage`, and `writePreimage` (tested for mappings and structs as well as plain numeric states)
- Moved `joinCommitments` and `findInputCommitments` to new `commitment-storage` file

Closes #156 