### PR TITLE
fix: addr in constructor fix + voting.zol changes

### DIFF
--- a/src/codeGenerators/orchestration/files/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/files/toOrchestration.ts
@@ -320,6 +320,17 @@ const prepareMigrationsFile = (file: localFile, node: any) => {
         });
       }
     });
+  } else if(constructorParamsIncludesAddr) {
+    // for each address in the shield contract constructor...
+    constructorAddrParams.forEach(name => {
+      // we have an address input which is likely not a another contract
+      // we just replace it with the default address
+      customImports += `const ${name} = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'; \n`;
+      logger.warn(
+        `Looks like you are using a constructor with a public address ${name}. This will be set to the default ganache test address.
+        If you'd like to change it, edit the variable in migrations/2_shield.js in the output zApp.`
+      );
+    });
   }
   if (node.functionNames.includes('cnstrctr')) {
     // we have a constructor which requires a proof

--- a/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
@@ -98,8 +98,11 @@ export default function codeGenerator(node: any, options: any = {}): any {
         return `\nlet ${node.declarations[0].name} = generalise(${codeGenerator(
           node.initialValue,
         )});`;
-      if (!node.initialValue.operator) // local var dec
+      if (!node.initialValue.operator) {
+        if (!node.initialValue.nodeType) return `\nlet ${codeGenerator(node.declarations[0])};`
+        // local var dec
         return `\nlet ${codeGenerator(node.declarations[0])} = ${codeGenerator(node.initialValue)};`;
+      } 
       return `\nlet ${codeGenerator(node.initialValue)};`;
     }
 

--- a/test/real-world-zapps/Voting.zol
+++ b/test/real-world-zapps/Voting.zol
@@ -17,7 +17,6 @@ contract Voting {
 
     function vote(secret uint256 proposalId) public {
       require(hasVoted[msg.sender] == false); // this is a secret test
-      require(proposals[proposalId] != bytes32(0));
       unknown proposalVotes[proposalId] += 1;
       hasVoted[msg.sender] = true;
     }
@@ -33,6 +32,7 @@ contract Voting {
     }
 
     function strikeVote(secret uint256 proposalId) public {
+      // NB - current implmentation requires at least two votes for proposalId before 1 can be struck
       require(msg.sender == admin);
       proposalVotes[proposalId] -= 1;
     }


### PR DESCRIPTION
A small fix for a bug found in `Voting.zol`:

- Addresses in the constructor automatically assume you have an imported contract, rather than a user's address. Now, if the compiler can't find a contract it will just put ganache's default address with a message to let the user know.
- The .zol originally had a public mapping indexed to by a secret key. I don't know of a way to call this mapping without revealing the secret value. In this case, if somebody votes for a non-proposal then it only impacts the user and should be ok.
- EDIT: added another fix since it was small: when we edit some mapping `x` inside a loop based on `i` with the mapping key being `i`, this means we have to extract and edit as many commitments as iterations, which is a TON of computation and very tricky to order. So I've disallowed it!

TODO: Hari suggested that we use the new variables in the testnet PR to extract the user's address, which is much nicer than ganache's default, so I will go ahead and implement this once testnet is in