### PR TITLE
Push npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
         with:
           node-version: '14.17.0'
       - run: |
-          ./bin/start
+          npm install
+          tsc
 
       - uses: codfish/semantic-release-action@master
         id: semantic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Publish starlight npm package
+
+on:
+  push:
+    branches: [master, miranda/npm]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14.17.0'
+      - run: |
+          ./bin/start
+
+      - uses: codfish/semantic-release-action@master
+        id: semantic
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: echo ${{ steps.semantic.outputs.release-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Publish starlight npm package
 
 on:
   push:
-    branches: [master, miranda/npm]
+    branches: [master, beta]
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Publish starlight npm package
 
 on:
   push:
-    branches: [master, beta]
+    branches: [master, beta, miranda/npm]
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Publish starlight npm package
 
 on:
   push:
-    branches: [master, beta, miranda/npm]
+    branches: [master, miranda/npm]
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ See [here](./doc/WRITEUP.md) for an enormously detailed explanation of how the t
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Quick User Guide](#quick-user-guide)
-- [Install](#install)
+- [Install via npm](#install-via-npm)
+  - [Troubleshooting](#troubleshooting)
+- [Install via clone](#install-via-clone)
 - [Run](#run)
   - [CLI options](#cli-options)
-- [Troubleshooting](#troubleshooting)
+- [Troubleshooting](#troubleshooting-1)
   - [Installation](#installation)
   - [Compilation](#compilation)
 - [Developer](#developer)
@@ -115,9 +117,36 @@ Run `zappify -i <./path/to/file>.zol` and get an entire standalone zApp in retur
 
 
 ---
-## Install
+## Install via npm
 
-Whilst the package is in early development, it isn't hosted on npm. To install:
+Starlight is now available on github's npm package repository!
+To install, run:
+
+`npm i @eyblockchain/starlight`
+
+Then you can import the `zappify` command like so:
+
+`import { zappify } from "@eyblockchain/starlight";`
+
+The only required input for `zappify` is the file path of the `.zol` file you'd like to compile, e.g. `zappify('./contracts/myContract.zol')`. You can optionally add a specific zApp name and the output directory:
+
+`zappify('./contracts/myContract.zol', 'myzApp', './test_zApps')`
+
+Then it works just as described in the below section [Run](#run).
+
+### Troubleshooting
+
+Since we push the npm package to github's repository, you may need to specify the package location in your project's `.npmrc` file. Try adding something like:
+
+```
+@eyblockchain:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=<your_github_token>
+```
+
+...and re-run the install command, or manually add `"@eyblockchain/starlight"` to your `package.json`.
+## Install via clone
+
+To install via github:
 
 Clone the repo.
 
@@ -150,7 +179,7 @@ This runs `tsc` and `npm i -g ./` which will create a symlink to your node.js bi
 
 ### Installation
 
-If the `zappify` command isn't working, try the [Install](#install) steps again. You might need to try `npm i --force -g ./`.
+If the `zappify` command isn't working, try the [Install](#install-via-clone) steps again. You might need to try `npm i --force -g ./`.
 
 In very rare cases, you might need to navigate to your node.js innards and delete zappify from the `bin` and `lib/node_modules`.
 To find where your npm lib is, type `npm` and it will tell you the path.

--- a/README.md
+++ b/README.md
@@ -119,10 +119,12 @@ Run `zappify -i <./path/to/file>.zol` and get an entire standalone zApp in retur
 ---
 ## Install via npm
 
-Starlight is now available on github's npm package repository!
-To install, run:
+Starlight is now available on **github's npm package** repository!
+To install, you need to make sure that `npm` is looking in that registry, not the default `npmjs`:
 
-`npm i @eyblockchain/starlight`
+`npm config set @eyblockchain:registry https://npm.pkg.github.com` <-- this sets any `@eyblockchain` packages to be installed from the github registry
+
+`npm i @eyblockchain/starlight@<latest-version>`
 
 Then you can import the `zappify` command like so:
 
@@ -136,7 +138,7 @@ Then it works just as described in the below section [Run](#run).
 
 ### Troubleshooting
 
-Since we push the npm package to github's repository, you may need to specify the package location in your project's `.npmrc` file. Try adding something like:
+Since we push the npm package to github's repository, you may need to specify the package location in your project's `.npmrc` file and authenticate to github. Try adding something like:
 
 ```
 @eyblockchain:registry=https://npm.pkg.github.com

--- a/index.mjs
+++ b/index.mjs
@@ -9,7 +9,7 @@ import { FilingError } from './built/error/errors.js';
 // This function is used to export into the published npm package
 // (it's basically a replacement for ./bin/index that npm understands)
 // locally, always use the command line zappify as defined in package.json
-export const zappify = (input, _zappName = input, output = './zapps', modify = false) => {
+export const zappify = (input, _zappName, output = './zapps', modify = false) => {
 
   const inputFilePath = input;
   const modifyAST = modify;

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,60 @@
+
+import fs from 'fs';
+import path from 'path';
+
+import mkdirs from './bin/mkdirs.mjs';
+import compile from './built/index.js';
+import { FilingError } from './built/error/errors.js';
+
+// This function is used to export into the published npm package
+// (it's basically a replacement for ./bin/index that npm understands)
+// locally, always use the command line zappify as defined in package.json
+export const zappify = (input, _zappName = input, output = './zapps', modify = false) => {
+
+  const inputFilePath = input;
+  const modifyAST = modify;
+  const inputFileName = path.parse(inputFilePath).name;
+  const zappName = _zappName || inputFileName;
+  const outputDirPath = `${output}/${zappName}`;
+  const configDirPath = `${outputDirPath}/config`;
+  const migrationsDirPath = `${outputDirPath}/migrations`;
+  const parseDirPath = `${outputDirPath}/parse`;
+  const circuitsDirPath = `${outputDirPath}/circuits`;
+  const contractsDirPath = `${outputDirPath}/contracts`;
+  const orchestrationDirPath = `${outputDirPath}/orchestration`;
+
+  const options = {
+    zappName,
+    inputFileName,
+    inputFilePath,
+    outputDirPath,
+    parseDirPath,
+    circuitsDirPath,
+    contractsDirPath,
+    orchestrationDirPath,
+    modifyAST,
+  };
+
+  if (!fs.existsSync(inputFilePath))
+  throw new FilingError(`inputFilePath "${inputFilePath}" does not exist.`);
+
+  if (path.parse(inputFilePath).ext !== '.zol')
+    if (path.parse(inputFilePath).ext === '.sol') {
+      console.warn(`We'd ordinarily expect a '.zol' file as input, but we'll try to compile this '.sol' file...`);
+    } else {
+      throw new FilingError(`Invalid input file extension. Expected '.zol' (a 'zappable' solidity file). Got '${path.parse(inputFilePath).ext}'.`);
+    }
+  fs.rmSync(parseDirPath, { recursive: true, force: true });
+  fs.rmSync(circuitsDirPath, { recursive: true, force: true });
+  fs.rmSync(contractsDirPath, { recursive: true, force: true });
+  fs.rmSync(orchestrationDirPath, { recursive: true, force: true });
+  fs.rmSync(configDirPath, { recursive: true, force: true });
+  fs.rmSync(migrationsDirPath, { recursive: true, force: true });
+
+  mkdirs(options);
+
+  compile(options)
+  
+}
+
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@eyblockchain/starlight",
   "version": "0.0.1",
   "description": "Create a zApp from Solidity",
-  "main": "bin/index.mjs",
+  "main": "built/index.js",
   "scripts": {
     "write-vk": "node /app/write-vk.mjs -i assign",
     "test": "mocha",
@@ -21,7 +21,7 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "files": ["./built/**/*", "./bin/*"],
+  "files": ["./built/**/*"],
   "release": {
     "branches": ["master", {"name": "miranda/npm", "prerelease": "beta"}]
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "registry": "https://npm.pkg.github.com"
   },
   "files": ["./built/**/*", "./bin/*"],
+  "release": {
+    "branches": ["master", {"name": "miranda/npm", "prerelease": true}]
+  }
+},
   "keywords": [
     "private contract",
     "zapp",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "starlight",
+  "name": "@eyblockchain/starlight",
   "version": "0.0.1",
   "description": "Create a zApp from Solidity",
   "main": "bin/index.mjs",
@@ -18,6 +18,10 @@
     "type": "git",
     "url": "git+https://github.com/EYBlockchain/starlight.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "files": ["./built/**/*", "./bin/*"],
   "keywords": [
     "private contract",
     "zapp",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "branches": [
       "master",
       {
-        "name": "beta",
+        "name": "miranda/npm",
         "prerelease": "beta"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "branches": [
       "master",
       {
-        "name": "miranda/npm",
+        "name": "beta",
         "prerelease": "beta"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "branches": [
       "master",
       {
-        "name": "miranda/npm",
+        "name": "beta",
         "prerelease": "beta"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "files": ["./built/**/*", "./bin/*"],
   "release": {
-    "branches": ["master", {"name": "miranda/npm", "prerelease": true}]
+    "branches": ["master", {"name": "miranda/npm", "prerelease": "beta"}]
   },
   "keywords": [
     "private contract",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "./built/**/*",
+    "./bin/mkdirs.mjs",
     "./index.mjs"
   ],
   "release": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "files": ["./built/**/*", "./bin/*"],
   "release": {
     "branches": ["master", {"name": "miranda/npm", "prerelease": true}]
-  }
-},
+  },
   "keywords": [
     "private contract",
     "zapp",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@eyblockchain/starlight",
   "version": "0.0.1",
   "description": "Create a zApp from Solidity",
-  "main": "built/index.js",
+  "main": "./index.mjs",
   "scripts": {
     "write-vk": "node /app/write-vk.mjs -i assign",
     "test": "mocha",
@@ -21,9 +21,18 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "files": ["./built/**/*"],
+  "files": [
+    "./built/**/*",
+    "./index.mjs"
+  ],
   "release": {
-    "branches": ["master", {"name": "miranda/npm", "prerelease": "beta"}]
+    "branches": [
+      "master",
+      {
+        "name": "miranda/npm",
+        "prerelease": "beta"
+      }
+    ]
   },
   "keywords": [
     "private contract",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "./index.mjs",
     "./src/boilerplate/common/**/*",
     "./contracts/**/*",
+    "./config/**/*",
     "./circuits/**/*"
   ],
   "release": {
@@ -65,15 +66,16 @@
     "chai": "^4.3.6",
     "commander": "^7.0.0",
     "config": "^3.3.7",
-    "express":"4.18.2",
     "crypto-js": "^4.1.1",
     "eslint": "^7.26.0",
+    "express": "4.18.2",
     "figlet": "^1.5.0",
     "fs-extra": "^10.0.1",
     "general-number": "^1.0.1",
     "json-diff": "^0.7.2",
     "json-diff-ts": "^1.2.4",
     "lodash.clonedeep": "^4.5.0",
+    "prettier": "^2.2.1",
     "solc": "^0.8.0",
     "typescript": "^4.2.3",
     "winston": "^3.3.3",
@@ -93,8 +95,7 @@
     "@types/prettier": "^2.4.4",
     "eslint": "^7.26.0",
     "eslint-config-codfish": "^9.0.2",
-    "mocha": "^8.2.1",
-    "prettier": "^2.2.1"
+    "mocha": "^8.2.1"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
   "files": [
     "./built/**/*",
     "./bin/mkdirs.mjs",
-    "./index.mjs"
+    "./index.mjs",
+    "./src/boilerplate/common/**/*",
+    "./contracts/**/*",
+    "./circuits/**/*"
   ],
   "release": {
     "branches": [

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'url';
 
 const testReadPath = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/generic-test.mjs');
 const pathPrefix = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/');
+const apiServiceReadPath = path.resolve(fileURLToPath(import.meta.url), '.../../../../../../src/boilerplate/common/services/generic-api_services.mjs');
+const apiRoutesReadPath = path.resolve(fileURLToPath(import.meta.url), '.../../../../../../src/boilerplate/common/routes/generic-api_routes.mjs');
 class BoilerplateGenerator {
   generateBoilerplate(node: any, fields: any = {}) {
     const { bpSection, bpType, ...otherParams } = node;

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -3,10 +3,11 @@
 // Q: how are we merging mapping key and ownerPK in edge case?
 // Q: should we reduce constraints a mapping's commitment's preimage by not having the extra inner hash? Not at the moment, because it adds complexity to transpilation.
 import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-const testReadPath = './src/boilerplate/common/generic-test.mjs';
-const apiServiceReadPath = './src/boilerplate/common/services/generic-api_services.mjs';
-const apiRoutesReadPath = './src/boilerplate/common/routes/generic-api_routes.mjs';
+const testReadPath = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/generic-test.mjs');
+const pathPrefix = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/');
 class BoilerplateGenerator {
   generateBoilerplate(node: any, fields: any = {}) {
     const { bpSection, bpType, ...otherParams } = node;
@@ -663,57 +664,57 @@ integrationApiRoutesBoilerplate = {
 zappFilesBoilerplate = () => {
   return [
     {
-      readPath: 'src/boilerplate/common/bin/startup',
+      readPath: pathPrefix + '/bin/startup',
       writePath: '/bin/startup',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/config/default.js',
+      readPath: pathPrefix + '/config/default.js',
       writePath: '/config/default.js',
       generic: false,
     },
     {
-      readPath: 'src/boilerplate/common/migrations/1_initial_migration.js',
+      readPath: pathPrefix + '/migrations/1_initial_migration.js',
       writePath: 'migrations/1_initial_migration.js',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/boilerplate-package.json',
+      readPath: pathPrefix + '/boilerplate-package.json',
       writePath: './package.json',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/boilerplate-docker-compose.yml',
+      readPath: pathPrefix + '/boilerplate-docker-compose.yml',
       writePath: './docker-compose.zapp.yml',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/boilerplate-Dockerfile',
+      readPath: pathPrefix + '/boilerplate-Dockerfile',
       writePath: './Dockerfile',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/boilerplate-Dockerfile.deployer',
+      readPath: pathPrefix + '/boilerplate-Dockerfile.deployer',
       writePath: './Dockerfile.deployer',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/boilerplate-Dockerfile.mongo',
+      readPath: pathPrefix + '/boilerplate-Dockerfile.mongo',
       writePath: './Dockerfile.mongo',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/setup-admin-user.js',
+      readPath: pathPrefix + '/setup-admin-user.js',
       writePath: './setup-admin-user.js',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/entrypoint.sh',
+      readPath: pathPrefix + '/entrypoint.sh',
       writePath: './entrypoint.sh',
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/truffle-config.js',
+      readPath: pathPrefix + '/truffle-config.js',
       writePath: './truffle-config.js',
       generic: true,
     },

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -8,8 +8,8 @@ import { fileURLToPath } from 'url';
 
 const testReadPath = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/generic-test.mjs');
 const pathPrefix = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/');
-const apiServiceReadPath = path.resolve(fileURLToPath(import.meta.url), '.../../../../../../src/boilerplate/common/services/generic-api_services.mjs');
-const apiRoutesReadPath = path.resolve(fileURLToPath(import.meta.url), '.../../../../../../src/boilerplate/common/routes/generic-api_routes.mjs');
+const apiServiceReadPath = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/services/generic-api_services.mjs');
+const apiRoutesReadPath = path.resolve(fileURLToPath(import.meta.url), '../../../../../../src/boilerplate/common/routes/generic-api_routes.mjs');
 class BoilerplateGenerator {
   generateBoilerplate(node: any, fields: any = {}) {
     const { bpSection, bpType, ...otherParams } = node;

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -721,7 +721,7 @@ zappFilesBoilerplate = () => {
       generic: true,
     },
     {
-      readPath: 'src/boilerplate/common/api.mjs',
+      readPath: pathPrefix + '/api.mjs',
       writePath: './orchestration/api.mjs',
       generic: true,
     },

--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -8,6 +8,35 @@ import NodePath from '../../../traverse/NodePath.js'
 import {traversePathsFast} from '../../../traverse/traverse.js'
 const Circuitbp = new CircuitBP();
 
+function poseidonLibraryChooser(fileObj: string) {
+  if (!fileObj.includes('poseidon')) return fileObj;
+  let poseidonFieldCount = 0;
+   var lines = fileObj.split('\n');
+   for(var line = 0; line < lines.length; line++) {
+     if(lines[line].includes('poseidon(')) {
+       poseidonFieldCount = 0;
+       for(var i = line+1; i<lines.length ; i++) {
+         if(lines[i].includes(',')) {
+           poseidonFieldCount++;
+         }
+         else
+           break;
+        }
+     }
+     if(poseidonFieldCount >4) break;
+   }
+     if(poseidonFieldCount <5) {
+     var lines = fileObj.split('\n');
+     for(var line = 0; line < lines.length; line++) {
+       if(lines[line].includes('./common/hashes/poseidon/poseidon.zok')) {
+         lines[line] = 'from "hashes/poseidon/poseidon.zok" import main as poseidon';
+       }
+     }
+     fileObj = lines.join('\n');
+   }
+   return fileObj;
+ }
+
 function codeGenerator(node: any) {
   switch (node.nodeType) {
     case 'Folder':
@@ -18,7 +47,7 @@ function codeGenerator(node: any) {
       const file = node.nodes.map(codeGenerator).join('\n\n');
       const thisFile = {
         filepath,
-        file,
+        file: poseidonLibraryChooser(file),
       };
       if (!file && node.fileName === `joinCommitments`) {
         thisFile.file = fs.readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../../../../circuits/common/joinCommitments.zok'), 'utf8');

--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-cycle, no-nested-ternary */
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 import { collectImportFiles } from '../../common.js'
 import CircuitBP from '../../../boilerplate/circuit/zokrates/raw/BoilerplateGenerator.js';
 import NodePath from '../../../traverse/NodePath.js'
@@ -20,7 +21,7 @@ function codeGenerator(node: any) {
         file,
       };
       if (!file && node.fileName === `joinCommitments`) {
-        thisFile.file = fs.readFileSync('./circuits/common/joinCommitments.zok', 'utf8');
+        thisFile.file = fs.readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../../../../circuits/common/joinCommitments.zok'), 'utf8');
       }
       const importedFiles = collectImportFiles(thisFile.file, 'circuit');
       return [thisFile, ...importedFiles];

--- a/src/codeGenerators/common.ts
+++ b/src/codeGenerators/common.ts
@@ -7,35 +7,6 @@ export interface localFile {
   file: string,
 }
 
-function poseidonLibraryChooser(fileObj:any ) {
-  let  poseidonFieldCount = 0;
-   var lines = fileObj.split('\n');
-   for(var line = 0; line < lines.length; line++) {
-     if(lines[line].includes('poseidon(')) {
-       poseidonFieldCount = 0;
-       for(var i = line+1; i<lines.length ; i++) {
-         if(lines[i].includes(',')) {
-           poseidonFieldCount++;
-         }
-         else
-           break;
-        }
-     }
-     if(poseidonFieldCount >4) break;
-   }
-     if(poseidonFieldCount <5) {
-     var lines = fileObj.split('\n');
-     for(var line = 0; line < lines.length; line++) {
-       if(lines[line].includes('./common/hashes/poseidon/poseidon.zok')) {
-         lines[line] = 'from "hashes/poseidon/poseidon.zok" import main as poseidon';
-       }
-     }
-     fileObj = lines.join('\n');
-   }
-   return fileObj;
- }
-
-
 /**
  * @param file - a stringified file
  * @param contextDirPath - the import statements of the `file` will be
@@ -50,9 +21,6 @@ export const collectImportFiles = (
   contextDirPath?: string,
   fileName: string = '',
 ) => {
-  if (context === 'circuit' && file.includes('poseidon')) {
-    file = poseidonLibraryChooser(file);;
-  }
   const lines = file.split('\n');
   let ImportStatementList: string[];
 

--- a/src/codeGenerators/common.ts
+++ b/src/codeGenerators/common.ts
@@ -7,6 +7,34 @@ export interface localFile {
   file: string,
 }
 
+function poseidonLibraryChooser(fileObj:any ) {
+  let  poseidonFieldCount = 0;
+   var lines = fileObj.split('\n');
+   for(var line = 0; line < lines.length; line++) {
+     if(lines[line].includes('poseidon(')) {
+       poseidonFieldCount = 0;
+       for(var i = line+1; i<lines.length ; i++) {
+         if(lines[i].includes(',')) {
+           poseidonFieldCount++;
+         }
+         else
+           break;
+        }
+     }
+     if(poseidonFieldCount >4) break;
+   }
+     if(poseidonFieldCount <5) {
+     var lines = fileObj.split('\n');
+     for(var line = 0; line < lines.length; line++) {
+       if(lines[line].includes('./common/hashes/poseidon/poseidon.zok')) {
+         lines[line] = 'from "hashes/poseidon/poseidon.zok" import main as poseidon';
+       }
+     }
+     fileObj = lines.join('\n');
+   }
+   return fileObj;
+ }
+
 
 /**
  * @param file - a stringified file
@@ -22,6 +50,9 @@ export const collectImportFiles = (
   contextDirPath?: string,
   fileName: string = '',
 ) => {
+  if (context === 'circuit' && file.includes('poseidon')) {
+    file = poseidonLibraryChooser(file);;
+  }
   const lines = file.split('\n');
   let ImportStatementList: string[];
 

--- a/src/codeGenerators/orchestration/files/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/files/toOrchestration.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-cycle, no-param-reassign */
 import fs from 'fs';
 import path from 'path';
+import {fileURLToPath} from 'url';
 import { collectImportFiles, localFile } from '../../common.js'
 import OrchestrationBP from '../../../boilerplate/orchestration/javascript/raw/boilerplate-generator.js';
 import codeGenerator from '../nodejs/toOrchestration.js';
@@ -412,7 +413,8 @@ export default function fileGenerator(node: any) {
         'orchestration',
       );
 
-      const startupScript = { filepath: 'bin/setup', file: fs.readFileSync('src/boilerplate/common/bin/setup', 'utf8')};
+      const readPath = path.resolve(fileURLToPath(import.meta.url), '../../../../../src/boilerplate/common/bin/setup');
+      const startupScript = { filepath: 'bin/setup', file: fs.readFileSync(readPath, 'utf8') };
       files.push(startupScript);
       const vkfile = files.filter(obj => obj.filepath.includes(`write-vk`))[0];
       const setupfile = files.filter(obj =>

--- a/src/transformers/toCircuit.ts
+++ b/src/transformers/toCircuit.ts
@@ -7,35 +7,39 @@ import visitor from './visitors/toCircuitVisitor.js';
 import codeGenerator from '../codeGenerators/circuit/zokrates/toCircuit.js';
 import { transformation1 } from './visitors/common.js';
 
-function poseidonLibraryChooser(fileObj:any ) {
- let  poseidonFieldCount = 0;
-  var lines = fileObj.file.split('\n');
-  for(var line = 0; line < lines.length; line++) {
-    if(lines[line].includes('poseidon(')) {
-    poseidonFieldCount = 0;
-    for(var i = line+1; i<lines.length ; i++) {
-    if(lines[i].includes(',')) {
-    poseidonFieldCount++;
-      }
-    else
-    break;
-        }
-      }
-      if(poseidonFieldCount >4)
-      break;
-    }
-    if(poseidonFieldCount <5) {
-    var lines = fileObj.file.split('\n');
-    for(var line = 0; line < lines.length; line++) {
-      if(lines[line].includes('./common/hashes/poseidon/poseidon.zok')) {
-        lines[line] = 'from "hashes/poseidon/poseidon.zok" import main as poseidon';
-      }
-    }
-    fileObj.file = lines.join('\n');
-  }
-  return fileObj;
-}
-
+// function poseidonLibraryChooser(fileObj:any ) {
+//  let  poseidonFieldCount = 0;
+//   var lines = fileObj.file.split('\n');
+//   for(var line = 0; line < lines.length; line++) {
+//     if(lines[line].includes('poseidon(')) {
+//       console.log(lines[line]);
+//       poseidonFieldCount = 0;
+//       for(var i = line+1; i<lines.length ; i++) {
+//         console.log(lines[i]);
+//         if(lines[i].includes(',')) {
+//           poseidonFieldCount++;
+//         }
+//         else
+//           break;
+//         }
+//     }
+//     if(poseidonFieldCount >4)
+//       break;
+//   }
+//     if(poseidonFieldCount <5) {
+//       console.log('adding small poseidon');
+//       console.log(poseidonFieldCount);
+//     var lines = fileObj.file.split('\n');
+//     for(var line = 0; line < lines.length; line++) {
+//       if(lines[line].includes('./common/hashes/poseidon/poseidon.zok')) {
+//         lines[line] = 'from "hashes/poseidon/poseidon.zok" import main as poseidon';
+//       }
+//     }
+//     fileObj.file = lines.join('\n');
+//   }
+//   return fileObj;
+// }
+// MON 5.12 WHY TF BIG FILE EVERY TIME
 // A transformer function which will accept an ast.
 export default function toCircuit(ast: any, options: any) {
   // transpile to a circuit AST:
@@ -63,9 +67,6 @@ export default function toCircuit(ast: any, options: any) {
   for (let fileObj of circuitFileData) {
     let filepath = pathjs.join(options.outputDirPath, fileObj.filepath);
     const dir = pathjs.dirname(filepath);
-    if(!filepath.includes('circuits/common/')) {
-    fileObj = poseidonLibraryChooser(fileObj);
-  }
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true }); // required to create the nested folders for common import files.
     fs.writeFileSync(filepath, fileObj.file);
   }

--- a/src/transformers/toCircuit.ts
+++ b/src/transformers/toCircuit.ts
@@ -7,39 +7,6 @@ import visitor from './visitors/toCircuitVisitor.js';
 import codeGenerator from '../codeGenerators/circuit/zokrates/toCircuit.js';
 import { transformation1 } from './visitors/common.js';
 
-// function poseidonLibraryChooser(fileObj:any ) {
-//  let  poseidonFieldCount = 0;
-//   var lines = fileObj.file.split('\n');
-//   for(var line = 0; line < lines.length; line++) {
-//     if(lines[line].includes('poseidon(')) {
-//       console.log(lines[line]);
-//       poseidonFieldCount = 0;
-//       for(var i = line+1; i<lines.length ; i++) {
-//         console.log(lines[i]);
-//         if(lines[i].includes(',')) {
-//           poseidonFieldCount++;
-//         }
-//         else
-//           break;
-//         }
-//     }
-//     if(poseidonFieldCount >4)
-//       break;
-//   }
-//     if(poseidonFieldCount <5) {
-//       console.log('adding small poseidon');
-//       console.log(poseidonFieldCount);
-//     var lines = fileObj.file.split('\n');
-//     for(var line = 0; line < lines.length; line++) {
-//       if(lines[line].includes('./common/hashes/poseidon/poseidon.zok')) {
-//         lines[line] = 'from "hashes/poseidon/poseidon.zok" import main as poseidon';
-//       }
-//     }
-//     fileObj.file = lines.join('\n');
-//   }
-//   return fileObj;
-// }
-// MON 5.12 WHY TF BIG FILE EVERY TIME
 // A transformer function which will accept an ast.
 export default function toCircuit(ast: any, options: any) {
   // transpile to a circuit AST:

--- a/src/transformers/visitors/checks/accessedVisitor.ts
+++ b/src/transformers/visitors/checks/accessedVisitor.ts
@@ -142,7 +142,7 @@ export default {
         // end of error checking
         // ------
         logger.debug(`Found an accessed secret state ${node.name}`);
-        if (config.get('log_level') === 'debug') backtrace.getSourceCode(node.src);
+        if (logger.level === 'debug') backtrace.getSourceCode(node.src);
         scope.getReferencedBinding(node)?.updateAccessed(path);
         const indicator = scope.getReferencedIndicator(node);
         if (indicator instanceof StateVariableIndicator) indicator.updateAccessed(path);

--- a/src/transformers/visitors/checks/incrementedVisitor.ts
+++ b/src/transformers/visitors/checks/incrementedVisitor.ts
@@ -175,7 +175,7 @@ export default {
       expressionNode.isDecremented = isDecremented;
 
       // print if in debug mode
-      if (config.get('log_level') === 'debug') backtrace.getSourceCode(node.src);
+      if (logger.level === 'debug') backtrace.getSourceCode(node.src);
       logger.debug(`statement is incremented? ${isIncremented}`);
       if (isIncremented && !isDecremented) {
         const incs = [];

--- a/src/traverse/Binding.ts
+++ b/src/traverse/Binding.ts
@@ -630,7 +630,7 @@ export class VariableBinding extends Binding {
       logger.debug(
         `Found a statement which burns the secret state and allows it to be reinitialised. If this line isn't meant to do that, check why you are setting the address to 0.`,
       );
-      if (config.get('log_level') === 'debug') backtrace.getSourceCode(node.src);
+      if (logger.level === 'debug') backtrace.getSourceCode(node.src);
       this.isBurned = true;
       // TODO more useful indicators here
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -17,7 +17,7 @@ function formatWithInspect(val: any) {
 }
 
 export default createLogger({
-  level: config.get('log_level') || 'info', // can be also edited using CLI option --log-level
+  level: config.has('log_level') ?  config.get('log_level') : 'info', // can be also edited using CLI option --log-level
   format: winston.format.combine(
     format.errors({ stack: true }),
     format.colorize(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "allowJs": true,
     "target": "es6",
     "moduleResolution": "node",
+    "module": "es2020",
     "esModuleInterop": true,
     "baseUrl": ".",
     "skipLibCheck": true,


### PR DESCRIPTION
Closes #169 

The long awaited npm package! It's for now pushed to the github packages repo, not npmjs, so you need to follow separate instructions to install. ~(TODO I'll add docs for this).~ (docs added)

Changes are:

- Add github actions to push package
- Add new `index.mjs` file purely for use by npm package (./bin/index is local only)
- Edit `package.json` to point to this new file and include all nec. files for the package to work
- Edit every use (yes, _every_ use) of `fs` to point to a relative path to the current file, rather than the current working directory

The last change is because we need the repo to work whether you pull starlight directly, or have it installed in your `./node_modules` folder. Every use of `fs` broke for the latter because we were relying on the user working in `./starlight`, not their own project.