### PR TITLE
Fix actions test failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.17.0'
+          node-version: '15.6.0'
 
       - name: run zappify
         run: |


### PR DESCRIPTION
The actions test fails after merging mongo, and _only_ in github actions, so I think it may be a versioning issue. Putting PR up so the tests run....

Edit: Seems to work!