### PR TITLE
Deploy to testnets - Polygon , Sepolia and Goerli with CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,25 @@ All the above use Docker in the background. If you'd like to see the Docker logg
 
 **NB: rerunning `npm test` will not work**, as the test script restarts the containers to ensure it runs an initialisation, removing the relevant dbs. If you'd like to rerun it from scratch, down the containers with `docker-compose -f docker-compose.zapp.yml down -v --remove-orphans` and delete the file `zapps/myContract/orchestration/common/db/preimage.json` before rerunning `npm test`.
 
+#### Deploy on public testnets
+
+Apart from local ganache instance, Starlight output zapps can be now be deployed in Sepolia, Goerli and Polygon Mumbai as cli options. Connection to Sepolia and Goerli are made through [infura](https://infura.io/) endpoints and that of Polygon Mumbai is provided via [maticvigil](https://rpc.maticvigil.com/).
+
+The configuration can be done during `./bin/setup` phase in the following way.
+
+`./bin/setup -n network -a account -k privatekey -m "12 letter mnemonic" -r APIKey`
+
+##### CLI options
+
+| option  | description  |
+|:--|:--|
+| `-n`  | Network : Specify testnet you want to connect to. possible options: `mumbai/ sepolia/ goerli`  |
+| `-a`  | Ethereum address |
+| `-k`  | Private key of above ethereum address |
+| `-m` -  | 12 letter mnemonic passphrase  |
+| `-r`  | API key or APPID of endpoint |
+| `-s`  | Zkp setup flag , Default to yes . If you had already created zkp keys before and just want to configure deployment infrastructure, pass `-s n`  |
+
 #### circuit
 
 `cd ./path/to/myCircuit.zok`

--- a/src/boilerplate/common/bin/setup
+++ b/src/boilerplate/common/bin/setup
@@ -78,7 +78,7 @@ perl -i -pe "s,10,500,g" bin/startup
 fi
 
 if [ ! -d "proving-files" ]; then
-  $setup='y'
+  setup='y'
 fi
 
 if [[ $setup == 'y' ]]

--- a/src/boilerplate/common/bin/setup
+++ b/src/boilerplate/common/bin/setup
@@ -81,7 +81,7 @@ if [ ! -d "proving-files" ]; then
   setup='y'
 fi
 
-if [[ $setup == 'y' ]]
+if [[ ! $setup == 'n' ]]
 then
 printf "\n${GREEN}*** Starting the zokrates container ***${NC}\n"
 

--- a/src/boilerplate/common/bin/setup
+++ b/src/boilerplate/common/bin/setup
@@ -5,6 +5,74 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+while getopts "n:a:m:k:r:" arg; do
+  case $arg in
+    n)
+      network=$OPTARG
+      echo networkvalue $OPTARG 
+      ;;
+    a)
+      account=$OPTARG
+      echo accountvalue $OPTARG
+      ;;
+    m)
+      mnemonic=$OPTARG
+      echo mnemonicvalue $OPTARG
+      ;;
+    k)
+      key=$OPTARG
+      echo keyvalue $OPTARG
+      ;;
+    r)
+      rpc=$OPTARG
+      echo rpcvalue $OPTARG
+      ;;
+  esac
+done
+
+cp docker-compose.zapp.override.default.yml docker-compose.zapp.override.yml
+
+cp entrypoint_default.sh entrypoint.sh
+
+cp bin/default_startup bin/startup
+
+perl -i -pe "s,docker-compose.zapp.yml -f docker-compose.zapp.override.yml,docker-compose.zapp.yml,g" package.json
+
+if [[ $network == 'polygon' ]] || [[ $network == 'sepolia' ]] || [[ $network == 'goerli' ]]
+then
+perl -i -pe "s,DEFAULT_ACCOUNT: '',DEFAULT_ACCOUNT: \'$account\',g" docker-compose.zapp.override.yml
+perl -i -pe "s,DEFAULT_ACCOUNT_MNEMONIC: '',DEFAULT_ACCOUNT_MNEMONIC: \'$mnemonic\',g" docker-compose.zapp.override.yml
+perl -i -pe "s,KEY: '',KEY: \'$key\',g" docker-compose.zapp.override.yml
+perl -i -pe "s,docker-compose.zapp.yml up,docker-compose.zapp.yml -f docker-compose.zapp.override.yml up,g" bin/startup
+perl -i -pe "s,docker-compose.zapp.yml,docker-compose.zapp.yml -f docker-compose.zapp.override.yml,g" package.json
+perl -i -pe "s,docker-compose -f docker-compose.zapp.yml up -d ganache, ## up ganache service for ganache,g" bin/startup
+fi
+
+if [[ $network == 'polygon' ]]
+then
+perl -i -pe "s,RPC_URL: '',RPC_URL: \'wss:\/\/rpc-mumbai.maticvigil.com\/ws\/v1\/$rpc\',g" docker-compose.zapp.override.yml
+perl -i -pe "s,development_ganache,polygon,g" entrypoint.sh
+perl -i -pe "s,while,##while,g" entrypoint.sh
+perl -i -pe "s,10,60,g" bin/startup
+fi
+
+
+if [[ $network == 'sepolia' ]]
+then
+perl -i -pe "s,RPC_URL: '',RPC_URL: \'wss://sepolia.infura.io/ws/v3//$rpc\',g" docker-compose.zapp.override.yml
+perl -i -pe "s,development_ganache,sepolia,g" entrypoint.sh
+perl -i -pe "s,while,##while,g" entrypoint.sh
+perl -i -pe "s,10,500,g" bin/startup
+fi
+
+if [[ $network == 'goerli' ]]
+then
+perl -i -pe "s,RPC_URL: '',RPC_URL: \'wss://goerli.infura.io/ws/v3/$rpc\',g" docker-compose.zapp.override.yml
+perl -i -pe "s,development_ganache,goerli,g" entrypoint.sh
+perl -i -pe "s,while,##while,g" entrypoint.sh
+perl -i -pe "s,10,500,g" bin/startup
+fi
+
 printf "\n${GREEN}*** Starting the zokrates container ***${NC}\n"
 
 docker-compose -f docker-compose.zapp.yml up -d zokrates
@@ -19,6 +87,6 @@ printf "\n${GREEN}*** Setup complete! Writing verification key to db... ***${NC}
 
 docker-compose -f docker-compose.zapp.yml run zapp node /app/write-vk.mjs -i ''
 
-CONSTRUCTOR_CALL
+
 
 printf "\n${GREEN}*** Finished! ***${NC}\n"

--- a/src/boilerplate/common/bin/setup
+++ b/src/boilerplate/common/bin/setup
@@ -5,7 +5,7 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-while getopts "n:a:m:k:r:" arg; do
+while getopts "n:a:m:k:r:s:" arg; do
   case $arg in
     n)
       network=$OPTARG
@@ -27,6 +27,10 @@ while getopts "n:a:m:k:r:" arg; do
       rpc=$OPTARG
       echo rpcvalue $OPTARG
       ;;
+    s)
+      setup=$OPTARG
+      echo setup $OPTARG
+      ;;
   esac
 done
 
@@ -38,7 +42,7 @@ cp bin/default_startup bin/startup
 
 perl -i -pe "s,docker-compose.zapp.yml -f docker-compose.zapp.override.yml,docker-compose.zapp.yml,g" package.json
 
-if [[ $network == 'polygon' ]] || [[ $network == 'sepolia' ]] || [[ $network == 'goerli' ]]
+if [[ $network == 'mumbai' ]] || [[ $network == 'sepolia' ]] || [[ $network == 'goerli' ]]
 then
 perl -i -pe "s,DEFAULT_ACCOUNT: '',DEFAULT_ACCOUNT: \'$account\',g" docker-compose.zapp.override.yml
 perl -i -pe "s,DEFAULT_ACCOUNT_MNEMONIC: '',DEFAULT_ACCOUNT_MNEMONIC: \'$mnemonic\',g" docker-compose.zapp.override.yml
@@ -48,10 +52,10 @@ perl -i -pe "s,docker-compose.zapp.yml,docker-compose.zapp.yml -f docker-compose
 perl -i -pe "s,docker-compose -f docker-compose.zapp.yml up -d ganache, ## up ganache service for ganache,g" bin/startup
 fi
 
-if [[ $network == 'polygon' ]]
+if [[ $network == 'mumbai' ]]
 then
 perl -i -pe "s,RPC_URL: '',RPC_URL: \'wss:\/\/rpc-mumbai.maticvigil.com\/ws\/v1\/$rpc\',g" docker-compose.zapp.override.yml
-perl -i -pe "s,development_ganache,polygon,g" entrypoint.sh
+perl -i -pe "s,development_ganache,mumbai,g" entrypoint.sh
 perl -i -pe "s,while,##while,g" entrypoint.sh
 perl -i -pe "s,10,60,g" bin/startup
 fi
@@ -73,6 +77,12 @@ perl -i -pe "s,while,##while,g" entrypoint.sh
 perl -i -pe "s,10,500,g" bin/startup
 fi
 
+if [ ! -d "proving-files" ]; then
+  $setup='y'
+fi
+
+if [[ $setup == 'y' ]]
+then
 printf "\n${GREEN}*** Starting the zokrates container ***${NC}\n"
 
 docker-compose -f docker-compose.zapp.yml up -d zokrates
@@ -89,4 +99,5 @@ docker-compose -f docker-compose.zapp.yml run zapp node /app/write-vk.mjs -i ''
 
 CONSTRUCTOR_CALL
 
+fi
 printf "\n${GREEN}*** Finished! ***${NC}\n"

--- a/src/boilerplate/common/bin/setup
+++ b/src/boilerplate/common/bin/setup
@@ -87,6 +87,6 @@ printf "\n${GREEN}*** Setup complete! Writing verification key to db... ***${NC}
 
 docker-compose -f docker-compose.zapp.yml run zapp node /app/write-vk.mjs -i ''
 
-
+CONSTRUCTOR_CALL
 
 printf "\n${GREEN}*** Finished! ***${NC}\n"

--- a/src/boilerplate/common/bin/setup
+++ b/src/boilerplate/common/bin/setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 GREEN='\033[0;32m'

--- a/src/boilerplate/common/bin/startup
+++ b/src/boilerplate/common/bin/startup
@@ -16,6 +16,6 @@ sleep 15
 
 docker-compose -f docker-compose.zapp.yml up -d timber
 
-sleep 5
+sleep 10
 
 docker-compose -f docker-compose.zapp.yml up -d zapp

--- a/src/boilerplate/common/boilerplate-Docker-compose.zapp.override.yml
+++ b/src/boilerplate/common/boilerplate-Docker-compose.zapp.override.yml
@@ -1,0 +1,23 @@
+version: '3.5'
+
+services:
+  zapp:
+    environment:
+      DEFAULT_ACCOUNT: ''
+      DEFAULT_ACCOUNT_MNEMONIC: ''
+      RPC_URL: ''
+      KEY: ''
+
+  deployer:
+    environment:
+      DEFAULT_ACCOUNT: ''
+      DEFAULT_ACCOUNT_MNEMONIC: ''
+      RPC_URL: ''
+      KEY: ''
+
+  timber:
+    environment:
+      DEFAULT_ACCOUNT: ''
+      DEFAULT_ACCOUNT_MNEMONIC: ''
+      RPC_URL: ''
+      KEY: ''

--- a/src/boilerplate/common/boilerplate-docker-compose.yml
+++ b/src/boilerplate/common/boilerplate-docker-compose.yml
@@ -26,6 +26,9 @@ services:
     environment:
       BLOCKCHAIN_HOST: ws://ganache
       BLOCKCHAIN_PORT: 8545
+      RPC_URL: ws://ganache:8545
+      DEFAULT_ACCOUNT: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+      KEY: '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
       LOG_LEVEL: info
       MONGO_HOST: mongodb://zapp-mongo
       MONGO_PORT: 27019
@@ -51,7 +54,9 @@ services:
       - zapp_network
 
   timber:
-    image: eyblockchain/timber:v3.0.3
+    build: 
+      context: https://github.com/EYBlockchain/timber.git#starlight/testnet:merkle-tree
+      dockerfile: Dockerfile
     restart: on-failure
     depends_on:
       - timber-mongo
@@ -68,6 +73,9 @@ services:
       UNIQUE_LEAVES: 'true'
       BLOCKCHAIN_HOST: ws://ganache
       BLOCKCHAIN_PORT: 8545
+      RPC_URL: ws://ganache:8545
+      DEFAULT_ACCOUNT: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+      KEY: '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
       CONTRACT_LOCATION: 'default'
       MONGO_HOST: mongodb://timber-mongo
       MONGO_PORT: 27017
@@ -108,7 +116,7 @@ services:
   
   ganache:
     image: trufflesuite/ganache:v7.4.4
-    command: --accounts=10 --gasLimit=100000000 --deterministic
+    command: --accounts=10 --gasLimit=100000000 --deterministic -i 1337
     ports:
       - '8545:8545'
     networks:
@@ -129,6 +137,9 @@ services:
     environment:
       BLOCKCHAIN_HOST: ws://ganache
       BLOCKCHAIN_PORT: 8545
+      RPC_URL: ws://ganache:8545
+      DEFAULT_ACCOUNT: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1'
+      KEY: '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d'
     networks:
       - zapp_network
 

--- a/src/boilerplate/common/boilerplate-package.json
+++ b/src/boilerplate/common/boilerplate-package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@babel/register": "^7.11.5",
     "@truffle/contract": "^4.2.21",
+    "@truffle/hdwallet-provider": "^1.4.0",
     "axios": "^0.19.2",
     "config": "^3.3.1",
     "express":"4.18.2",

--- a/src/boilerplate/common/config/default.js
+++ b/src/boilerplate/common/config/default.js
@@ -91,16 +91,23 @@ module.exports = {
   web3: {
     host: process.env.BLOCKCHAIN_HOST,
     port: process.env.BLOCKCHAIN_PORT,
-    url: `${process.env.BLOCKCHAIN_HOST}:${process.env.BLOCKCHAIN_PORT}`,
+    // url: `${process.env.BLOCKCHAIN_HOST}:${process.env.BLOCKCHAIN_PORT}`,
+    url: process.env.RPC_URL,
+    rpcUrl: process.env.RPC_URL,
+    defaultAccountMnemonic: process.env.DEFAULT_ACCOUNT_MNEMONIC,
+    key: process.env.KEY,
 
     options: {
-      defaultAccount: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
-      defaultBlock: '0', // e.g. the genesis block our blockchain
-      defaultGas: 90000000,
+      // defaultAccount: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+      defaultAccount: process.env.DEFAULT_ACCOUNT,
+      defaultGas: 5221975,
       defaultGasPrice: 20000000000,
-      transactionBlockTimeout: 50,
-      transactionConfirmationBlocks: 15,
-      transactionPollingTimeout: 480,
+      // defaultBlock: '0', // e.g. the genesis block our blockchain
+      // defaultGas: 90000000,
+      // defaultGasPrice: 20000000000,
+      // transactionBlockTimeout: 50,
+      // transactionConfirmationBlocks: 15,
+      // transactionPollingTimeout: 480,
       // transactionSigner: new CustomTransactionSigner()
     },
   },

--- a/src/boilerplate/common/contract.mjs
+++ b/src/boilerplate/common/contract.mjs
@@ -134,10 +134,19 @@ export async function registerKey(
 	}
 	if (registerWithContract) {
 		const instance = await getContractInstance(contractName);
-		await instance.methods.registerZKPPublicKey(publicKey.integer).send({
+		const contractAddr = await getContractAddress(contractName); 
+		const txData = await instance.methods.registerZKPPublicKey(publicKey.integer).encodeABI();	
+		let txParams = {
 			from: config.web3.options.defaultAccount,
+			to: contractAddr,
 			gas: config.web3.options.defaultGas,
-		});
+			gasPrice: config.web3.options.defaultGasPrice,
+			data: txData,
+			chainId: await web3.eth.net.getId(),
+		};
+		const key = config.web3.key;
+		const signed = await web3.eth.accounts.signTransaction(txParams, key);
+		const sendTxn = await web3.eth.sendSignedTransaction(signed.rawTransaction);
 	}
 	const keyJson = {
 		secretKey: secretKey.integer,

--- a/src/boilerplate/common/generic-test.mjs
+++ b/src/boilerplate/common/generic-test.mjs
@@ -2,8 +2,6 @@ import FUNCTION_NAME from './FUNCTION_NAME.mjs';
 import { startEventFilter, getSiblingPath } from './common/timber.mjs';
 import logger from './common/logger.mjs';
 import web3 from './common/web3.mjs';
-import { enc } from 'crypto-js';
-
 
 
 // 'sleep' just creates a delay, ensuring the tests don't overlap

--- a/src/boilerplate/common/generic-test.mjs
+++ b/src/boilerplate/common/generic-test.mjs
@@ -2,6 +2,7 @@ import FUNCTION_NAME from './FUNCTION_NAME.mjs';
 import { startEventFilter, getSiblingPath } from './common/timber.mjs';
 import logger from './common/logger.mjs';
 import web3 from './common/web3.mjs';
+import { enc } from 'crypto-js';
 
 
 
@@ -37,27 +38,27 @@ describe('FUNCTION_NAME', async function () {
         await startEventFilter('CONTRACT_NAME');
         // this calls your function! It returns the tx from the shield contract
         // you can replace the values below - numbers are randomly generated
-        const { tx } = await FUNCTION_NAME(FUNCTION_SIG_1);
+        const { tx , encEvent } = await FUNCTION_NAME(FUNCTION_SIG_1);
         // prints the tx
         console.log(tx);
         // reassigns leafIndex to the index of the first commitment added by this function
-        if (tx.events.NewLeaves) {
-          leafIndex = tx.events.NewLeaves.returnValues[0];
+        if (tx.event) {
+          leafIndex = tx.returnValues[0];
           // prints the new leaves (commitments) added by this function call
           console.log(`Merkle tree event returnValues:`);
-          console.log(tx.events.NewLeaves.returnValues);
+          console.log(tx.returnValues[0]);
         }
-        if (tx.events.EncryptedData) {
-          if (tx.events.EncryptedData.length) {
-            encryption.msgs = tx.events.EncryptedData[0].returnValues[0];
-            encryption.key = tx.events.EncryptedData[0].returnValues[1];
+        if (encEvent.event) {
+          if (encEvent.event.EncryptedData.length) {
+            encryption.msgs = encEvent.event.EncryptedData[0].returnValues[0];
+            encryption.key = encEvent.event.EncryptedData[0].returnValues[1];
             console.log("EncryptedMsgs:");
-            console.log(tx.events.EncryptedData[0].returnValues[0]);
+            console.log(encEvent.event.EncryptedData[0].returnValues[0]);
           } else {
-            encryption.msgs = tx.events.EncryptedData.returnValues[0];
-            encryption.key = tx.events.EncryptedData.returnValues[1];
+            encryption.msgs = encEvent.event.EncryptedData.returnValues[0];
+            encryption.key = encEvent.event.EncryptedData.returnValues[1];
             console.log("EncryptedMsgs:");
-            console.log(tx.events.EncryptedData.returnValues);
+            console.log(tencEvent.event.EncryptedData.returnValues);
           }
         }
         await sleep(10);
@@ -85,9 +86,9 @@ describe('FUNCTION_NAME', async function () {
       try {
         // this calls your function a second time for incremental cases
         const { tx } = await FUNCTION_NAME(FUNCTION_SIG_2);
-        if (tx.events.NewLeaves) {
+        if (tx.event) {
           console.log(`Merkle tree event returnValues:`);
-          console.log(tx.events.NewLeaves.returnValues);
+          console.log(tx.returnValues[0]);
         }
       } catch (err) {
         logger.error(err);

--- a/src/boilerplate/common/services/generic-api_services.mjs
+++ b/src/boilerplate/common/services/generic-api_services.mjs
@@ -33,28 +33,28 @@ export async function service_FUNCTION_NAME (req, res, next){
 	try {
     await startEventFilter('CONTRACT_NAME');
     const FUNCTION_SIG;
-    const { tx ,  _RESPONSE_} = await FUNCTION_NAME(FUNCTION_SIG);
+    const { tx , encEvent, _RESPONSE_} = await FUNCTION_NAME(FUNCTION_SIG);
     // prints the tx
     console.log(tx);
-    res.send({tx, _RESPONSE_});
+    res.send({tx, encEvent, _RESPONSE_});
     // reassigns leafIndex to the index of the first commitment added by this function
-    if (tx.events.NewLeaves) {
-      leafIndex = tx.events.NewLeaves.returnValues[0];
+    if (tx.event) {
+      leafIndex = tx.returnValues[0];
       // prints the new leaves (commitments) added by this function call
       console.log(`Merkle tree event returnValues:`);
-      console.log(tx.events.NewLeaves.returnValues);
+      console.log(tx.returnValues);
     }
-    if (tx.events.EncryptedData) {
-      if (tx.events.EncryptedData.length) {
-        encryption.msgs = tx.events.EncryptedData[0].returnValues[0];
-        encryption.key = tx.events.EncryptedData[0].returnValues[1];
+    if (encEvent.event) {
+      if (encEvent.event.EncryptedData.length) {
+        encryption.msgs = encEvent.event.EncryptedData[0].returnValues[0];
+        encryption.key = encEvent.event.EncryptedData[0].returnValues[1];
         console.log("EncryptedMsgs:");
-        console.log(tx.events.EncryptedData[0].returnValues[0]);
+        console.log(encEvent.event.EncryptedData[0].returnValues[0]);
       } else {
-        encryption.msgs = tx.events.EncryptedData.returnValues[0];
-        encryption.key = tx.events.EncryptedData.returnValues[1];
+        encryption.msgs = encEvent.event.EncryptedData.returnValues[0];
+        encryption.key = encEvent.event.EncryptedData.returnValues[1];
         console.log("EncryptedMsgs:");
-        console.log(tx.events.EncryptedData.returnValues);
+        console.log(encEvent.event.EncryptedData.returnValues);
       }
     }
     await sleep(10);

--- a/src/boilerplate/common/truffle-config.js
+++ b/src/boilerplate/common/truffle-config.js
@@ -50,7 +50,7 @@ module.exports = {
       network_id: 1337, // Any network (default: none)
       gas: 10000000,
     },
-    polygon: {
+    mumbai: {
       networkCheckTimeout: 10000,
       provider: () => new HDWalletProvider(mnemonic, rpcUrl),
       network_id: 80001,

--- a/src/boilerplate/common/truffle-config.js
+++ b/src/boilerplate/common/truffle-config.js
@@ -18,11 +18,13 @@
  *
  */
 
-// const HDWalletProvider = require('@truffle/hdwallet-provider');
+const HDWalletProvider = require('@truffle/hdwallet-provider');
 // const infuraKey = "fj4jll3k.....";
 //
 // const fs = require('fs');
 // const mnemonic = fs.readFileSync(".secret").toString().trim();
+const rpcUrl = process.env.RPC_URL;
+const mnemonic = process.env.DEFAULT_ACCOUNT_MNEMONIC;
 
 module.exports = {
   /**
@@ -45,8 +47,35 @@ module.exports = {
     development_ganache: {
       host: 'ganache', // Localhost (default: none)
       port: 8545, // Standard Ethereum port (default: none)
-      network_id: '*', // Any network (default: none)
+      network_id: 1337, // Any network (default: none)
       gas: 10000000,
+    },
+    polygon: {
+      networkCheckTimeout: 10000,
+      provider: () => new HDWalletProvider(mnemonic, rpcUrl),
+      network_id: 80001,
+      confirmations: 2,
+      timeoutBlocks: 200,
+      port: 8545,
+      skipDryRun: true
+    },
+    sepolia: {
+      provider: () => new HDWalletProvider(mnemonic, rpcUrl),
+      network_id: 11155111,
+      gas:8500000,
+      gasPrice:20000000000,
+      confirmations: 2,
+      timeoutBlocks:200,
+      skipDryRun: true
+    },
+    goerli: {
+      provider: () => new HDWalletProvider(mnemonic, rpcUrl),
+      network_id: 5,
+      gas:8500000,
+      gasPrice:20000000000,
+      confirmations: 2,
+      timeoutBlocks:200,
+      skipDryRun: true
     },
     // localhost: {
     //   host: 'localhost', // Localhost (default: none)

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -166,7 +166,7 @@ class BoilerplateGenerator {
                 \n${stateName}_witness_0 = await getMembershipWitness('${contractName}', generalise(${stateName}_0_oldCommitment._id).integer);
                 \n${stateName}_witness_1 = await getMembershipWitness('${contractName}', generalise(${stateName}_1_oldCommitment._id).integer);
 
-                \n const tx = await joinCommitments('${contractName}', '${mappingName}${mappingKey}', secretKey, publicKey, [${stateVarId.join(' , ')}], [${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment], [${stateName}_witness_0, ${stateName}_witness_1], instance);
+                \n const tx = await joinCommitments('${contractName}', '${mappingName}${mappingKey}', secretKey, publicKey, [${stateVarId.join(' , ')}], [${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment], [${stateName}_witness_0, ${stateName}_witness_1], instance, contractAddr, web3);
 
                 ${stateName}_preimage = await getCommitmentsById(${stateName}_stateVarId);
 
@@ -319,14 +319,16 @@ class BoilerplateGenerator {
         `\nimport GN from 'general-number';`,
         `\nimport fs from 'fs';
         \n`,
-        `\nimport { getContractInstance, registerKey } from './common/contract.mjs';`,
+        `\nimport { getContractInstance, getContractAddress, registerKey } from './common/contract.mjs';`,
         `\nimport { storeCommitment, getCurrentWholeCommitment, getCommitmentsById, getAllCommitments, getInputCommitments, joinCommitments, markNullified } from './common/commitment-storage.mjs';`,
         `\nimport { generateProof } from './common/zokrates.mjs';`,
         `\nimport { getMembershipWitness, getRoot } from './common/timber.mjs';`,
+        `\nimport Web3 from './common/web3.mjs';`,
         `\nimport { decompressStarlightKey, poseidonHash } from './common/number-theory.mjs';
         \n`,
         `\nconst { generalise } = GN;`,
         `\nconst db = '/app/orchestration/common/db/preimage.json';`,
+        `const web3 = Web3.connection();`,
         `\nconst keyDb = '/app/orchestration/common/db/key.json';\n\n`,
       ];
     },
@@ -668,6 +670,11 @@ zappFilesBoilerplate = () => {
       generic: true,
     },
     {
+      readPath: 'src/boilerplate/common/bin/startup',
+      writePath: '/bin/default_startup',
+      generic: true,
+    },
+    {
       readPath: 'src/boilerplate/common/config/default.js',
       writePath: '/config/default.js',
       generic: false,
@@ -685,6 +692,16 @@ zappFilesBoilerplate = () => {
     {
       readPath: 'src/boilerplate/common/boilerplate-docker-compose.yml',
       writePath: './docker-compose.zapp.yml',
+      generic: true,
+    },
+    {
+      readPath: 'src/boilerplate/common/boilerplate-Docker-compose.zapp.override.yml',
+      writePath: './docker-compose.zapp.override.yml',
+      generic: true,
+    },
+    {
+      readPath: 'src/boilerplate/common/boilerplate-Docker-compose.zapp.override.yml',
+      writePath: './docker-compose.zapp.override.default.yml',
       generic: true,
     },
     {
@@ -710,6 +727,11 @@ zappFilesBoilerplate = () => {
     {
       readPath: 'src/boilerplate/common/entrypoint.sh',
       writePath: './entrypoint.sh',
+      generic: true,
+    },
+    {
+      readPath: 'src/boilerplate/common/entrypoint.sh',
+      writePath: './entrypoint_default.sh',
       generic: true,
     },
     {


### PR DESCRIPTION
Closes #133 
Closes #158 
This PR adds support to deploy Zapps to polygon POS testnet , Sepolia and Goerli.

Infura endpoints are used for connecting to Sepolia and Goerli websockets whereas to deploy on polygon testnet, maticvigil endpoints are utlized.

Changes

- Since Zapps are now connected to Infura or maticvigil, which doesn't support web.eth.sendTransaction. (For it to support that, it would need to know your private key, but it's a shared public node.) , you need to either sign the transaction locally using `web3.eth.accounts.signTransaction `then send via `web3.eth.sendSignedTransaction`.
-  Modify the way starlight listen to contract emitted events
- Use `Docker-compose.zapp.override.yml` to config testnet 


Testnets can be configured via CLI at setup phase .

To deploy on ganache 
 run `./bin/setup`

To deploy in polygon , sepolia or goerli
run `./bin/setup -n networkname -a publicaddress -k privatekey -m "12 word mnemonic" -r APIKEY`

