### PR TITLE
Quick commitment storage fix for joined commitments

### DIFF
--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -344,7 +344,7 @@ export async function joinCommitments(
 
 	let tx = await instance.getPastEvents("allEvents");
 
-	tx = tx[0];	
+	tx = tx[0];
 
 	await markNullified(generalise(commitments[0]._id), secretKey.hex(32));
 	await markNullified(generalise(commitments[1]._id), secretKey.hex(32));
@@ -353,7 +353,7 @@ export async function joinCommitments(
 		name: statename,
 		mappingKey: fromID,
 		preimage: {
-			stateVarId: generalise(stateVarID),
+			stateVarId: generalise(oldCommitment_stateVarId),
 			value: newCommitment_value,
 			salt: newCommitment_newSalt,
 			publicKey: publicKey,

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -350,6 +350,8 @@ export async function joinCommitments(
 	await markNullified(generalise(commitments[1]._id), secretKey.hex(32));
 	await storeCommitment({
 		hash: newCommitment,
+		name: statename,
+		mappingKey: fromID,
 		preimage: {
 			stateVarId: generalise(stateVarID),
 			value: newCommitment_value,

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -166,7 +166,7 @@ class BoilerplateGenerator {
                 \n${stateName}_witness_0 = await getMembershipWitness('${contractName}', generalise(${stateName}_0_oldCommitment._id).integer);
                 \n${stateName}_witness_1 = await getMembershipWitness('${contractName}', generalise(${stateName}_1_oldCommitment._id).integer);
 
-                \n const tx = await joinCommitments('${contractName}', '${mappingName}${mappingKey}', secretKey, publicKey, [${stateVarId.join(' , ')}], [${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment], [${stateName}_witness_0, ${stateName}_witness_1], instance, contractAddr, web3);
+                \n const tx = await joinCommitments('${contractName}', '${mappingName}', secretKey, publicKey, [${stateVarId.join(' , ')}], [${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment], [${stateName}_witness_0, ${stateName}_witness_1], instance, contractAddr, web3);
 
                 ${stateName}_preimage = await getCommitmentsById(${stateName}_stateVarId);
 


### PR DESCRIPTION
This PR is a small fix I introduced when merging in my changes which added a `name` and `mappingKey` field to stored commitments. I neglected to add these fields to the stored commitment output from a join circuit!

Have tested with 2 zols and works fine - used the testnet branch as a base and didn't include local changes to sending txs for join commitments, so drafting for now.