### PR TITLE
Single warning for struct properties with unconstrained variable

### DIFF
--- a/src/transformers/visitors/ownership/errorChecksVisitor.ts
+++ b/src/transformers/visitors/ownership/errorChecksVisitor.ts
@@ -7,6 +7,8 @@ import NodePath from '../../../traverse/NodePath.js';
 import { traverseNodesFast } from '../../../traverse/traverse.js';
 import { ZKPError, TODOError, SyntaxError } from '../../../error/errors.js';
 import { KeyObject } from 'crypto';
+import logger from '../../../utils/logger.js';
+export let structWarnings = [];
 
 
 /**
@@ -169,6 +171,9 @@ export default {
       for (const [, binding] of Object.entries(scope.bindings)) {
         if (!(binding instanceof VariableBinding)) continue;
         binding.prelimTraversalErrorChecks();
+      }
+      if(structWarnings.length>0) {
+      logger.warn( ' The following struct properties may cause unconstrained variable errors in the circuit ' , Array.from(new Set(structWarnings)));
       }
       // if no errors, we then check everything is nullifiable
       for (const [, binding] of Object.entries(scope.bindings)) {

--- a/src/traverse/Indicator.ts
+++ b/src/traverse/Indicator.ts
@@ -7,6 +7,7 @@ import { VariableBinding } from './Binding.js';
 import logger from '../utils/logger.js';
 import backtrace from '../error/backtrace.js';
 import { SyntaxUsageError } from '../error/errors.js';
+import { structWarnings } from '../transformers/visitors/ownership/errorChecksVisitor.js';
 
 
 export class ContractDefinitionIndicator {
@@ -714,9 +715,7 @@ export class StateVariableIndicator extends FunctionDefinitionIndicator {
           mappingKey.prelimTraversalErrorChecks();
         } else {
           mappingKey.node = this.referencingPaths[0].getStructDeclaration(this.node).members.find(n => n.name === name);
-          logger.warn(
-             `Struct property ${name} of ${this.name} is not referenced/edited in this scope (${this.scope.scopeName}), this may cause unconstrained variable errors in the circuit.`,
-           );
+          structWarnings.push(name.concat(' in ').concat(this.scope.scopeName));
         }
       }
     }

--- a/src/traverse/MappingKey.ts
+++ b/src/traverse/MappingKey.ts
@@ -4,6 +4,7 @@ import { StateVariableIndicator } from './Indicator.js';
 import logger from '../utils/logger.js';
 import { SyntaxUsageError, ZKPError } from '../error/errors.js';
 import backtrace from '../error/backtrace.js';
+import { structWarnings } from '../transformers/visitors/ownership/errorChecksVisitor.js';
 
 /**
  * If a Binding/StateVarIndicator represents a mapping, it will contain a MappingKey class.
@@ -312,10 +313,8 @@ export default class MappingKey {
        if (this.structProperties[name] instanceof MappingKey) {
         this.structProperties[name].prelimTraversalErrorChecks();
        } else {
-         logger.warn(
-            `Struct property ${name} of ${this.name} is not referenced/edited in this scope (${this.keyPath.scope.scopeName}), this may cause unconstrained variable errors in the circuit.`,
-          );
-       }
+        structWarnings.push(name.concat(' in ').concat(this.keyPath.scope.scopeName));
+      }
      }
    }
   }


### PR DESCRIPTION
This PR is a small feature to reduce number of warning messages produced due to unconstrained struct variables. The unconstrained list are collected at `errorCheckVisitor.js` and thrown as single warning. 