### PR TITLE
Require statement for partitioned states + fix for modifier 

### DIFF
--- a/src/parse/removeDecorators.ts
+++ b/src/parse/removeDecorators.ts
@@ -198,7 +198,7 @@ function arrangeModifiers(substrings: any) {
 
         for (var j=0; j<i; j++) {
 
-          if (substrings[j].startsWith(modifierslist))  {
+          if (substrings[j].startsWith(modifierslist) && (modifierslist != 'modifier '))  {
 
             ParameterList = substrings[j].slice(
               substrings[j].indexOf('(') + 1,

--- a/src/transformers/visitors/checks/requireStatementVisitor.ts
+++ b/src/transformers/visitors/checks/requireStatementVisitor.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign, no-shadow */
 import NodePath from '../../../traverse/NodePath.js';
 import { VariableBinding } from '../../../traverse/Binding.js';
+import { SyntaxUsageError } from '../../../error/errors.js';
 /**
  * @desc:
  * This visitor considers whether a require statement (and the variables it evaluates) should remain publicly visible in the smart contract, or whether the statement should be checked within a circuit, to preserve secrecy of variables.
@@ -18,6 +19,11 @@ export default {
       const visitor = (path: NodePath, state: any) => {
         const binding = path.getReferencedBinding();
         if (binding instanceof VariableBinding && binding.isSecret) {
+          if(binding.isPartitioned)
+          throw new SyntaxUsageError(
+            `Require statement cannot be used on partioned secret state ' ${binding.name} ' . Starlight handles this check internally when partioned states are nullfied.`,
+            node,
+          );
           state.requireStatementPrivate = true;
           state.stopTraversal = true;
         }

--- a/test/contracts/modifier.zol
+++ b/test/contracts/modifier.zol
@@ -26,4 +26,7 @@ contract Owner {
       function beta() private onlyOwner onlyUser {
     a+=2;
     }
+      function gamma() private {
+    a+=5;
+    }
 }


### PR DESCRIPTION
Closes #188 
Small fix that throws a Syntax error when require statements are used for partitioned states.

Also adding a fix for handling modifiers in contracts that have mixture of functions with modifiers and functions without modifiers.