### PR TITLE
Failed transaction and unsigned integer fix

### DIFF
--- a/src/boilerplate/common/generic-test.mjs
+++ b/src/boilerplate/common/generic-test.mjs
@@ -47,17 +47,10 @@ describe('FUNCTION_NAME', async function () {
           console.log(tx.returnValues[0]);
         }
         if (encEvent.event) {
-          if (encEvent.event.EncryptedData.length) {
-            encryption.msgs = encEvent.event.EncryptedData[0].returnValues[0];
-            encryption.key = encEvent.event.EncryptedData[0].returnValues[1];
+            encryption.msgs = encEvent[0].returnValues[0];
+            encryption.key = encEvent[0].returnValues[1];
             console.log("EncryptedMsgs:");
-            console.log(encEvent.event.EncryptedData[0].returnValues[0]);
-          } else {
-            encryption.msgs = encEvent.event.EncryptedData.returnValues[0];
-            encryption.key = encEvent.event.EncryptedData.returnValues[1];
-            console.log("EncryptedMsgs:");
-            console.log(tencEvent.event.EncryptedData.returnValues);
-          }
+            console.log(encEvent[0].returnValues[0]);
         }
         await sleep(10);
       } catch (err) {

--- a/src/boilerplate/common/services/generic-api_services.mjs
+++ b/src/boilerplate/common/services/generic-api_services.mjs
@@ -45,18 +45,11 @@ export async function service_FUNCTION_NAME (req, res, next){
       console.log(tx.returnValues);
     }
     if (encEvent.event) {
-      if (encEvent.event.EncryptedData.length) {
-        encryption.msgs = encEvent.event.EncryptedData[0].returnValues[0];
-        encryption.key = encEvent.event.EncryptedData[0].returnValues[1];
-        console.log("EncryptedMsgs:");
-        console.log(encEvent.event.EncryptedData[0].returnValues[0]);
-      } else {
-        encryption.msgs = encEvent.event.EncryptedData.returnValues[0];
-        encryption.key = encEvent.event.EncryptedData.returnValues[1];
-        console.log("EncryptedMsgs:");
-        console.log(encEvent.event.EncryptedData.returnValues);
-      }
-    }
+      encryption.msgs = encEvent[0].returnValues[0];
+      encryption.key = encEvent[0].returnValues[1];
+      console.log("EncryptedMsgs:");
+      console.log(encEvent[0].returnValues[0]);
+  }
     await sleep(10);
   } catch (err) {
     logger.error(err);

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -790,6 +790,9 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
             \n 	const sendTxn = await web3.eth.sendSignedTransaction(signed.rawTransaction);
             \n  let tx = await instance.getPastEvents("NewLeaves");
             \n tx = tx[0];\n
+            \n if (!tx) {
+              throw new Error( 'Tx failed - the commitment was not accepted on-chain, or the contract is not deployed.');
+            } \n
             let encEvent = '';
             \n try {
             \n  encEvent = await instance.getPastEvents("EncryptedData");

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -612,6 +612,11 @@ DoWhileStatement: {
   VariableDeclaration: {
     enter(path: NodePath, state : any) {
       const { node, parent, scope } = path;
+      
+      if(node.typeName.name === 'uint')
+      throw new Error(
+        `SyntaxError: VariableDeclarations is uint, please specify the size (from 8 to 256 bits, in steps of 8) of declared variable ${node.name}.`,
+      );
 
       if (path.isFunctionReturnParameterDeclaration())
         throw new Error(

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -615,7 +615,7 @@ DoWhileStatement: {
       
       if(node.typeName.name === 'uint')
       throw new Error(
-        `SyntaxError: VariableDeclarations is uint, please specify the size (from 8 to 256 bits, in steps of 8) of declared variable ${node.name}.`,
+        `VariableDeclarations is uint, please specify the size (from 8 to 256 bits, in steps of 8) of declared variable ${node.name}.`,
       );
 
       if (path.isFunctionReturnParameterDeclaration())

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign, no-shadow */
 
-// import logger from '../../utils/logger.mjs';
+ import logger from '../../utils/logger.js';
 import cloneDeep from 'lodash.clonedeep';
 import { buildNode } from '../../types/solidity-types.js';
 import { traverseNodesFast } from '../../traverse/traverse.js';
@@ -614,10 +614,10 @@ DoWhileStatement: {
       const { node, parent, scope } = path;
       
       if(node.typeName.name === 'uint')
-      throw new Error(
+      logger.warn(
         `VariableDeclarations is uint, please specify the size (from 8 to 256 bits, in steps of 8) of declared variable ${node.name}.`,
       );
-
+//
       if (path.isFunctionReturnParameterDeclaration())
         throw new Error(
           `TODO: VariableDeclarations of return parameters are tricky to initialise because we might rearrange things so they become _input_ parameters to the circuit. Future enhancement.`,

--- a/test/contracts/Assign-InternalFunctionCall.zol
+++ b/test/contracts/Assign-InternalFunctionCall.zol
@@ -6,7 +6,7 @@ contract FakeBank {
 
     secret mapping(uint256 => uint256) public account;
 
-    function deposit(secret uint256 accountId, secret uint amountDeposit) public {
+    function deposit(secret uint256 accountId, secret uint256 amountDeposit) public {
     account[accountId] += amountDeposit;
 
     }

--- a/test/contracts/Assign-InternalFunctionCall.zol
+++ b/test/contracts/Assign-InternalFunctionCall.zol
@@ -6,7 +6,7 @@ contract FakeBank {
 
     secret mapping(uint256 => uint256) public account;
 
-    function deposit(secret uint256 accountId, secret uint256 amountDeposit) public {
+    function deposit(secret uint256 accountId, secret uint amountDeposit) public {
     account[accountId] += amountDeposit;
 
     }

--- a/test/contracts/BucketsOfBalls.zol
+++ b/test/contracts/BucketsOfBalls.zol
@@ -6,7 +6,7 @@ contract BucketsOfBalls {
 
     secret mapping(uint256 => uint256) public buckets;
 
-    function deposit(secret uint256 bucketId, uint amountDeposit) public {
+    function deposit(secret uint256 bucketId, uint256 amountDeposit) public {
         unknown buckets[bucketId] += amountDeposit;
     }
 


### PR DESCRIPTION
These are the small fixes :
1. First, if we have a failed `tx`, instead of trying it to store the new commitment, we throw an error.
2. Whenever we have a `unsigned` variable declared without size specification, it sometime result in error during the `sig` check in shield contract. 
3. Reading cipher text and encryption keys correctly from the emitted event. 