### PR TITLE
Public Params in Function Signature

### DIFF
--- a/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
@@ -114,11 +114,10 @@ class FunctionBoilerplateGenerator {
       if (indicators.msgSenderParam) publicParams.unshift({ name: 'msg.sender', type:'address' , dummy: true, inCircuit: true});
       if (indicators.msgValueParam) publicParams.unshift({ name: 'msg.value', type:'uint256' , dummy: true,  inCircuit: true});
       let internalFunctionEncryptionRequired = false;
-      let internalFncParams = [];
+
 
       path.node._newASTPointer.body.statements?.forEach((node) => {
         if(node.expression?.nodeType === 'InternalFunctionCall'){
-          internalFncParams = node.expression.parameters;
           if(node.expression.parameters.includes('cipherText') ) 
            internalFunctionEncryptionRequired = true 
 
@@ -134,7 +133,6 @@ class FunctionBoilerplateGenerator {
       return {
         ...(publicParams?.length && { customInputs: publicParams }),
         functionName,
-        internalFncParams,
         ...indicators,
       };
     },

--- a/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
@@ -74,8 +74,6 @@ class FunctionBoilerplateGenerator {
       const { indicators } = this.scope;
       const isConstructor = this.scope.path.node.kind === 'constructor' ? true : false;
 
-
-
       const { nullifiersRequired, oldCommitmentAccessRequired, msgSenderParam, msgValueParam, containsAccessedOnlyState, encryptionRequired } = indicators;
       const newCommitmentsRequired = indicators.newCommitmentsRequired;
       const nullifierRootRequired = indicators.nullifiersRequired;
@@ -109,26 +107,37 @@ class FunctionBoilerplateGenerator {
       const publicParams = params?.filter((p: any) => (!p.isSecret && p.interactsWithSecret)).map((p: any) => customInputsMap(p)).concat(customInputs);
       const functionName = path.getUniqueFunctionName();
       const indicators = this.customFunction.getIndicators.bind(this)();
+
   
 
       // special check for msgSender and msgValue param. If msgsender is found, prepend a msgSender uint256 param to the contact's function.
       if (indicators.msgSenderParam) publicParams.unshift({ name: 'msg.sender', type:'address' , dummy: true});
       if (indicators.msgValueParam) publicParams.unshift({ name: 'msg.value', type:'uint256' , dummy: true});
       let internalFunctionEncryptionRequired = false;
+      let isinternalFunctionCall = false;
+      let internalFncParams = [];
       path.node._newASTPointer.body.statements?.forEach((node) => {
-        if(node.expression?.nodeType === 'InternalFunctionCall')
-        if(node.expression.parameters.includes('cipherText') ) 
-        internalFunctionEncryptionRequired = true 
+        if(node.expression?.nodeType === 'InternalFunctionCall'){
+          isinternalFunctionCall = true;
+          internalFncParams = node.expression.parameters;
+          if(node.expression.parameters.includes('cipherText') ) 
+           internalFunctionEncryptionRequired = true 
+
+        }
+        
       })
 
 
       if(path.node.returnParameters.parameters.length === 0 && !indicators.encryptionRequired && !internalFunctionEncryptionRequired) {
         publicParams?.push({ name: 1, type: 'uint256', dummy: true });
       }
+
       return {
         ...(publicParams?.length && { customInputs: publicParams }),
         functionName,
         funcParams,
+        isinternalFunctionCall,
+        internalFncParams,
         ...indicators,
       };
     },

--- a/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
@@ -104,6 +104,7 @@ class FunctionBoilerplateGenerator {
       }
 
       const params = path.getFunctionParameters();
+      const funcParams = params?.map((p: any) => customInputsMap(p)).concat(customInputs);
       const publicParams = params?.filter((p: any) => (!p.isSecret && p.interactsWithSecret)).map((p: any) => customInputsMap(p)).concat(customInputs);
       const functionName = path.getUniqueFunctionName();
       const indicators = this.customFunction.getIndicators.bind(this)();
@@ -126,6 +127,7 @@ class FunctionBoilerplateGenerator {
       return {
         ...(publicParams?.length && { customInputs: publicParams }),
         functionName,
+        funcParams,
         ...indicators,
       };
     },

--- a/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
@@ -104,7 +104,8 @@ class FunctionBoilerplateGenerator {
       }
 
       const params = path.getFunctionParameters();
-      const funcParams = params?.map((p: any) => customInputsMap(p)).concat(customInputs);
+      
+      const funcParams = params?.filter((p: any) => (!p.isSecret)).map((p: any) => customInputsMap(p)).concat(customInputs);
       const publicParams = params?.filter((p: any) => (!p.isSecret && p.interactsWithSecret)).map((p: any) => customInputsMap(p)).concat(customInputs);
       const functionName = path.getUniqueFunctionName();
       const indicators = this.customFunction.getIndicators.bind(this)();

--- a/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/FunctionBoilerplateGenerator.ts
@@ -103,7 +103,6 @@ class FunctionBoilerplateGenerator {
 
       const params = path.getFunctionParameters();
       
-      // const funcParams = params?.filter((p: any) => (!p.isSecret)).map((p: any) => customInputsMap(p)).concat(customInputs);
       const publicParams = params?.filter((p: any) => !p.isSecret).map((p: any) => customInputsMap(p)).concat(customInputs);
       const functionName = path.getUniqueFunctionName();
       const indicators = this.customFunction.getIndicators.bind(this)();

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -55,9 +55,7 @@ class FunctionBoilerplateGenerator {
     postStatements({
       functionName,
       customInputs, // array of custom input names
-      funcParams,
       isConstructor,
-      internalFncParams,
       nullifiersRequired: newNullifiers,
       oldCommitmentAccessRequired: commitmentRoot,
       newCommitmentsRequired: newCommitments,
@@ -66,7 +64,7 @@ class FunctionBoilerplateGenerator {
       // prettier-ignore
 
       let parameter = [
-      ...(funcParams ? funcParams.map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
+      ...(customInputs ? customInputs.map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
       ...(newNullifiers ? [`uint256`] : []),
       ...(newNullifiers ? [`uint256`] : []),
       ...(newNullifiers ? [`uint256[]`] : []), 

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -56,9 +56,8 @@ class FunctionBoilerplateGenerator {
       functionName,
       customInputs, // array of custom input names
       funcParams,
-      isinternalFunctionCall,
+      isConstructor,
       internalFncParams,
-      nullifierRootRequired : nullifierRootRequired,
       nullifiersRequired: newNullifiers,
       oldCommitmentAccessRequired: commitmentRoot,
       newCommitmentsRequired: newCommitments,
@@ -68,8 +67,8 @@ class FunctionBoilerplateGenerator {
 
       let parameter = [
       ...(funcParams ? funcParams.map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
-      ...((nullifierRootRequired || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
-      ...((nullifierRootRequired || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
+      ...((newNullifiers || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
+      ...((newNullifiers || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
       ...((newNullifiers || internalFncParams.includes('newNullifiers'))? [`uint256[]`] : []), 
       ...((commitmentRoot || internalFncParams.includes('commitmentRoot')) ? [`uint256`] : []),
       ...((newCommitments || internalFncParams.includes('newCommitments')) ? [`uint256[]`] : []),
@@ -84,7 +83,9 @@ class FunctionBoilerplateGenerator {
       });
 
     
-      let msgSigCheck = ([...(!isinternalFunctionCall ? [] : [`bytes4 sig = bytes4(keccak256("${functionName}(${parameter})")) ;  \n \t \t \t if (sig == msg.sig)`])]);
+      let msgSigCheck = ([...(isConstructor  ? [] : [`bytes4 sig = bytes4(keccak256("${functionName}(${parameter})")) ;  \n \t \t \t if (sig == msg.sig)`])]);
+
+      customInputs = customInputs?.filter(p => p.inCircuit);
 
       return [
         `
@@ -100,10 +101,10 @@ class FunctionBoilerplateGenerator {
           }).join('\n')}`]
           : []),
 
-          ...(nullifierRootRequired ? [`
+          ...(newNullifiers ? [`
           inputs.nullifierRoot = nullifierRoot; `] : []),
 
-          ...(nullifierRootRequired ? [`
+          ...(newNullifiers ? [`
           inputs.latestNullifierRoot = latestNullifierRoot; `] : []),
 
 

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -64,7 +64,7 @@ class FunctionBoilerplateGenerator {
       // prettier-ignore
 
       let parameter = [
-      ...(customInputs ? customInputs.map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
+      ...(customInputs ? customInputs.filter(input => !input.dummy && input.isParam).map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
       ...(newNullifiers ? [`uint256`] : []),
       ...(newNullifiers ? [`uint256`] : []),
       ...(newNullifiers ? [`uint256[]`] : []), 

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -67,13 +67,13 @@ class FunctionBoilerplateGenerator {
 
       let parameter = [
       ...(funcParams ? funcParams.map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
-      ...((newNullifiers || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
-      ...((newNullifiers || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
-      ...((newNullifiers || internalFncParams.includes('newNullifiers'))? [`uint256[]`] : []), 
-      ...((commitmentRoot || internalFncParams.includes('commitmentRoot')) ? [`uint256`] : []),
-      ...((newCommitments || internalFncParams.includes('newCommitments')) ? [`uint256[]`] : []),
-      ...((encryptionRequired || internalFncParams.includes('cipherText')) ? [`uint256[][]`] : []),
-      ...((encryptionRequired || internalFncParams.includes('ephPubKeys')) ? [`uint256[2][]`] : []),
+      ...(newNullifiers ? [`uint256`] : []),
+      ...(newNullifiers ? [`uint256`] : []),
+      ...(newNullifiers ? [`uint256[]`] : []), 
+      ...(commitmentRoot  ? [`uint256`] : []),
+      ...(newCommitments  ? [`uint256[]`] : []),
+      ...(encryptionRequired  ? [`uint256[][]`] : []),
+      ...(encryptionRequired ? [`uint256[2][]`] : []),
       `uint256[]`,
     ].filter(para => para !== undefined); // Added for return parameter 
 

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -56,32 +56,35 @@ class FunctionBoilerplateGenerator {
       functionName,
       customInputs, // array of custom input names
       funcParams,
+      isinternalFunctionCall,
+      internalFncParams,
       nullifierRootRequired : nullifierRootRequired,
       nullifiersRequired: newNullifiers,
       oldCommitmentAccessRequired: commitmentRoot,
       newCommitmentsRequired: newCommitments,
-      encryptionRequired,
-      isConstructor
+      encryptionRequired
     }): string[] {
       // prettier-ignore
 
       let parameter = [
       ...(funcParams ? funcParams.map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
-      ...(nullifierRootRequired ? [`uint256`] : []),
-      ...(nullifierRootRequired ? [`uint256`] : []),
-      ...(newNullifiers ? [`uint256[]`] : []), 
-      ...(commitmentRoot ? [`uint256`] : []),
-      ...(newCommitments ? [`uint256[]`] : []),
-      ...(encryptionRequired ? [`uint256[][]`] : []),
-      ...(encryptionRequired ? [`uint256[2][]`] : []),
+      ...((nullifierRootRequired || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
+      ...((nullifierRootRequired || internalFncParams.includes('nullifierRoot')) ? [`uint256`] : []),
+      ...((newNullifiers || internalFncParams.includes('newNullifiers'))? [`uint256[]`] : []), 
+      ...((commitmentRoot || internalFncParams.includes('commitmentRoot')) ? [`uint256`] : []),
+      ...((newCommitments || internalFncParams.includes('newCommitments')) ? [`uint256[]`] : []),
+      ...((encryptionRequired || internalFncParams.includes('cipherText')) ? [`uint256[][]`] : []),
+      ...((encryptionRequired || internalFncParams.includes('ephPubKeys')) ? [`uint256[2][]`] : []),
       `uint256[]`,
     ].filter(para => para !== undefined); // Added for return parameter 
 
+   
       customInputs?.forEach((input, i) => {
         if (input.structName) customInputs[i] = input.properties;
       });
 
-      let msgSigCheck = ([...(isConstructor ? [] : [`bytes4 sig = bytes4(keccak256("${functionName}(${parameter})")) ;  \n \t \t \t if (sig == msg.sig)`])]);
+    
+      let msgSigCheck = ([...(!isinternalFunctionCall ? [] : [`bytes4 sig = bytes4(keccak256("${functionName}(${parameter})")) ;  \n \t \t \t if (sig == msg.sig)`])]);
 
       return [
         `

--- a/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/FunctionBoilerplateGenerator.ts
@@ -55,6 +55,7 @@ class FunctionBoilerplateGenerator {
     postStatements({
       functionName,
       customInputs, // array of custom input names
+      funcParams,
       nullifierRootRequired : nullifierRootRequired,
       nullifiersRequired: newNullifiers,
       oldCommitmentAccessRequired: commitmentRoot,
@@ -65,7 +66,7 @@ class FunctionBoilerplateGenerator {
       // prettier-ignore
 
       let parameter = [
-      ...(customInputs ? customInputs.filter(input => !input.dummy && input.isParam).map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
+      ...(funcParams ? funcParams.map(input => input.structName ? `(${input.properties.map(p => p.type)})` : input.type) : []),
       ...(nullifierRootRequired ? [`uint256`] : []),
       ...(nullifierRootRequired ? [`uint256`] : []),
       ...(newNullifiers ? [`uint256[]`] : []), 

--- a/src/codeGenerators/contract/solidity/toContract.ts
+++ b/src/codeGenerators/contract/solidity/toContract.ts
@@ -8,6 +8,7 @@ import FunctionBP from '../../../boilerplate/contract/solidity/raw/FunctionBoile
 const contractBP = new ContractBP();
 const functionBP = new FunctionBP();
 
+
 function codeGenerator(node: any) {
   // We'll break things down by the `type` of the `node`.
   switch (node.nodeType) {
@@ -80,10 +81,12 @@ function codeGenerator(node: any) {
           break;
 
       }
+
       const functionSignature = `${functionType} (${codeGenerator(node.parameters)}) ${node.visibility} ${node.stateMutability} {`;
-      const body = codeGenerator(node.body);
-
-
+      let body = codeGenerator(node.body);
+      let msgSigCheck = body.slice(body.indexOf('bytes4 sig'), body.indexOf('verify') )
+      if(!node.msgSigRequired)
+        body = body.replace(msgSigCheck, ' ');
     return `
       ${functionSignature}
 

--- a/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/circuitInternalFunctionCallVisitor.ts
@@ -24,15 +24,7 @@ const internalCallVisitor = {
               if(childNode.nodeType === 'FunctionDefinition'){
                 state.newParameterList = cloneDeep(childNode.parameters.parameters);
                 state.newReturnParameterList = cloneDeep(childNode.returnParameters.parameters);
-                // node._newASTPointer.forEach(file => {
-                //   if(file.fileName === state.callingFncName[index].name){
-                //     file.nodes.forEach(childNode => {
-                //       if(childNode.nodeType === 'FunctionDefinition'){
-                //         let callParameterList = cloneDeep(childNode.parameters.parameters);
-                //        }
-                //      })
-                //    }
-                //  })
+                
                  state.newParameterList.forEach((node, nodeIndex) => {
                   if(node.nodeType === 'Boilerplate') {
                     for(const [id, oldStateName] of  state.oldStateArray.entries()) {
@@ -47,11 +39,9 @@ const internalCallVisitor = {
                      for(const [id, oldStateName] of state.oldStateArray.entries()) {
                        if(oldStateName !== state.newStateArray[name][id].name)
                        node.name = state.newStateArray[name][id].name;
-                    node.name = node.name.replace('_'+oldStateName, '_'+state.newStateArray[name][id].name)
-                    if(state.newStateArray[name][id].memberName)
+                       node.name = node.name.replace('_'+oldStateName, '_'+state.newStateArray[name][id].name)
+                       if(state.newStateArray[name][id].memberName)
                        state.newParameterList.splice(nodeIndex,1);
-                       else
-                       node.name = node.name.replace(oldStateName, state.newStateArray[name][id].name)
                      }
                    }
                  })
@@ -62,8 +52,6 @@ const internalCallVisitor = {
                  node.name = node.name.replace('_'+oldStateName, '_'+state.newStateArray[name][id].name)
                  if(state.newStateArray[name][id].memberName)
                     state.state.newReturnParameterList.splice(nodeIndex,1);
-                    else
-                    node.name = node.name.replace(oldStateName, state.newStateArray[name][id].name)
                   }
                  })
                }
@@ -124,6 +112,7 @@ const internalCallVisitor = {
                 state.circuitArguments.push(param);
                }
              });
+
             node._newASTPointer.forEach(file => {
               if(file.fileName === state.callingFncName[index].name){
                 file.nodes.forEach(childNode => {

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -231,6 +231,7 @@ export default {
             if(node.nodeType === 'FunctionDefinition' && node.kind === 'function'){
               state.internalFncName?.forEach( (name, index) => {
                 if(node.name === name) {
+                  node.msgSigRequired = true;
                  state.postStatements ??= [];
                  state.postStatements = cloneDeep(node.body.postStatements);
                 }
@@ -271,6 +272,7 @@ export default {
     enter(path: NodePath, state: any) {
       const { node, parent } = path;
       const isConstructor = node.kind === 'constructor';
+      state.msgSigRequired = false;
       if(node.kind === 'fallback' || node.kind === 'receive')
       {
         node.fileName = node.kind;
@@ -278,6 +280,7 @@ export default {
       }
       else
       state.functionName = path.getUniqueFunctionName();
+
       const newNode = buildNode('FunctionDefinition', {
         name: node.fileName || state.functionName,
         id: node.id,
@@ -285,6 +288,7 @@ export default {
         stateMutability: node.stateMutability === 'payable'? node.stateMutability : '',
         visibility: node.kind ==='function' ? 'public' : node.kind === 'constructor'? '': 'external',
         isConstructor,
+        msgSigRequired: state.msgSigRequired,
       });
 
       node._newASTPointer = newNode;
@@ -302,12 +306,13 @@ export default {
     exit(path: NodePath, state: any) {
       // We populate the entire shield contract upon exit, having populated the FunctionDefinition's scope by this point.
       const { node, scope } = path;
-
+  
       const newFunctionDefinitionNode = node._newASTPointer;
-
+ 
       // Let's populate the `parameters` and `body`:
       const { parameters } = newFunctionDefinitionNode.parameters;
       const { postStatements, preStatements } = newFunctionDefinitionNode.body;
+     
 
       // if contract is entirely public, we don't want zkp related boilerplate
       if (!path.scope.containsSecret && !(node.kind === 'constructor')) return;
@@ -334,9 +339,9 @@ export default {
             bpSection: 'postStatements',
             scope,
             customInputs: state.customInputs,
+           
           }),
         );
-
       delete state?.customInputs;
     },
   },

--- a/src/transformers/visitors/toContractVisitor.ts
+++ b/src/transformers/visitors/toContractVisitor.ts
@@ -891,7 +891,9 @@ DoWhileStatement: {
            state.fnParameters.push(args[index]);
 
          });
-         const params = [...(internalfnDefIndicators.nullifiersRequired? [`nullifierRoot, latestNullifierRoot, newNullifiers`] : []),
+         const params = [...(internalfnDefIndicators.nullifiersRequired? [`nullifierRoot`] : []),
+               ...(internalfnDefIndicators.nullifiersRequired? [`latestNullifierRoot`] : []),
+               ...(internalfnDefIndicators.nullifiersRequired?  [`newNullifiers`] : []), 
                ...(internalfnDefIndicators.oldCommitmentAccessRequired ? [`commitmentRoot`] : []),
                ...(internalfnDefIndicators.newCommitmentsRequired ? [`newCommitments`] : []),
                ...(internalfnDefIndicators.containsAccessedOnlyState ? [`checkNullifiers`] : []),

--- a/src/types/solidity-types.ts
+++ b/src/types/solidity-types.ts
@@ -149,6 +149,7 @@ export function buildNode(nodeType: string, fields: any = {}): any {
         isConstructor,
         kind,
         stateMutability,
+        msgSigRequired,
         body = buildNode('Block'),
         parameters = buildNode('ParameterList'),
         returnParameters = buildNode('ParameterList'), // TODO
@@ -161,6 +162,7 @@ export function buildNode(nodeType: string, fields: any = {}): any {
         isConstructor,
         kind,
         stateMutability,
+        msgSigRequired,
         body,
         parameters,
         returnParameters,


### PR DESCRIPTION
When creating a function signature we considered only public parameters  interacting with secrets and in some zapps e.g. `internalFunctionCallTest2.zol` have completely public parameters. They weren't considered for function signature resulting `transaction failure`