### PR TITLE
Redeployment scripts for constructor proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,18 @@ You can also filter these commitments by variable name. Using the example above,
 ```
 as a GET request to `http://localhost:3000/getCommitmentsByVariableName`.
 
+#### Using secret states in the constructor
+
+Starlight handles secret initiation in the constructor by creating a proof at the setup stage. Any user supplied inputs will be prompted for in the command line when running `./bin/setup`.
+
+Since this inevitably creates a commitment to be sent your local db, simply restarting the zapp will **not** work. The blockchain will be aware of the constructor commitment, but your zapp will not.
+
+If you would like to restart the zapp and redeploy the contract, always (with no running docker containers) run:
+
+`./bin/redeploy` <-- creates a new constructor proof and saves the commitment, then deploys the shield contract
+
+`npm run restart` <-- if you'd like to use the APIs, always **restart** rather than **start** since the latter clears your local dbs
+
 #### Deploy on public testnets
 
 Apart from local ganache instance, Starlight output zapps can be now be deployed in Sepolia, Goerli and Polygon Mumbai as cli options. Connection to Sepolia and Goerli are made through [infura](https://infura.io/) endpoints and that of Polygon Mumbai is provided via [maticvigil](https://rpc.maticvigil.com/).

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ If you would like to restart the zapp and redeploy the contract, always (with no
 
 `npm run restart` <-- if you'd like to use the APIs, always **restart** rather than **start** since the latter clears your local dbs
 
+Then, if you previously had nullifiers, reinstate them in your local sparse merkle tree by sending a POST to `http://localhost:3000/reinstateNullifiers`.
+
 #### Deploy on public testnets
 
 Apart from local ganache instance, Starlight output zapps can be now be deployed in Sepolia, Goerli and Polygon Mumbai as cli options. Connection to Sepolia and Goerli are made through [infura](https://infura.io/) endpoints and that of Polygon Mumbai is provided via [maticvigil](https://rpc.maticvigil.com/).

--- a/src/boilerplate/common/bin/redeploy
+++ b/src/boilerplate/common/bin/redeploy
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+CONSTRUCTOR_CALL && docker-compose -f docker-compose.zapp.yml up -d deployer

--- a/src/boilerplate/common/boilerplate-package.json
+++ b/src/boilerplate/common/boilerplate-package.json
@@ -5,6 +5,7 @@
     "test": "./bin/startup && docker-compose -f docker-compose.zapp.yml run zapp npx mocha --exit --require @babel/register 'orchestration/test.mjs'",
     "retest": "docker-compose -f docker-compose.zapp.yml run zapp npx mocha --exit --require @babel/register 'orchestration/test.mjs'",
     "start": "./bin/startup && docker-compose -f docker-compose.zapp.yml run --name apiservice -p 3000:3000 zapp node orchestration/api.mjs",
+    "restart": "docker-compose -f docker-compose.zapp.yml run --name apiservice -p 3000:3000 zapp node orchestration/api.mjs",
     "apitest": "./bin/setup && ./bin/startup && docker-compose -f docker-compose.zapp.yml run --name apiservice -d -p 3000:3000 zapp node orchestration/api.mjs"
   },
   "keywords": [

--- a/src/boilerplate/common/boilerplate-package.json
+++ b/src/boilerplate/common/boilerplate-package.json
@@ -5,7 +5,7 @@
     "test": "./bin/startup && docker-compose -f docker-compose.zapp.yml run zapp npx mocha --exit --require @babel/register 'orchestration/test.mjs'",
     "retest": "docker-compose -f docker-compose.zapp.yml run zapp npx mocha --exit --require @babel/register 'orchestration/test.mjs'",
     "start": "./bin/startup && docker-compose -f docker-compose.zapp.yml run --name apiservice -p 3000:3000 zapp node orchestration/api.mjs",
-    "restart": "docker-compose -f docker-compose.zapp.yml run --name apiservice -p 3000:3000 zapp node orchestration/api.mjs",
+    "restart": "docker rm apiservice && docker-compose -f docker-compose.zapp.yml run --name apiservice -p 3000:3000 zapp node orchestration/api.mjs",
     "apitest": "./bin/setup && ./bin/startup && docker-compose -f docker-compose.zapp.yml run --name apiservice -d -p 3000:3000 zapp node orchestration/api.mjs"
   },
   "keywords": [

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -693,7 +693,7 @@ integrationApiServicesBoilerplate = {
     `
   },
   preStatements(): string{
-    return ` import { startEventFilter, getSiblingPath } from './common/timber.mjs';\nimport fs from "fs";\nimport logger from './common/logger.mjs';\nimport { decrypt } from "./common/number-theory.mjs";\nimport { getAllCommitments, getCommitmentsByState } from "./common/commitment-storage.mjs";\nimport web3 from './common/web3.mjs';\n\n
+    return ` import { startEventFilter, getSiblingPath } from './common/timber.mjs';\nimport fs from "fs";\nimport logger from './common/logger.mjs';\nimport { decrypt } from "./common/number-theory.mjs";\nimport { getAllCommitments, getCommitmentsByState, reinstateNullifiers } from "./common/commitment-storage.mjs";\nimport web3 from './common/web3.mjs';\n\n
         /**
       NOTE: this is the api service file, if you need to call any function use the correct url and if Your input contract has two functions, add() and minus().
       minus() cannot be called before an initial add(). */
@@ -740,7 +740,21 @@ integrationApiServicesBoilerplate = {
           logger.error(err);
           res.send({ errors: [err.message] });
         }
-      }`;
+      }
+      
+      export async function service_reinstateNullifiers(req, res, next) {
+        try {
+          await reinstateNullifiers();
+          res.send('Complete');
+          await sleep(10);
+        } catch (err) {
+          logger.error(err);
+          res.send({ errors: [err.message] });
+        }
+      }`
+      
+      
+      ;
   }
 
 
@@ -759,12 +773,14 @@ integrationApiRoutesBoilerplate = {
         (fs.readFileSync(apiRoutesReadPath, 'utf8').match(/router.post?[\s\S]*/g)|| [])[0]}`
   },
   commitmentImports(): string {
-    return `import { service_allCommitments, service_getCommitmentsByState } from "./api_services.mjs";\n`;
+    return `import { service_allCommitments, service_getCommitmentsByState, service_reinstateNullifiers } from "./api_services.mjs";\n`;
   },
   commitmentRoutes(): string {
     return `// commitment getter routes
     router.get("/getAllCommitments", service_allCommitments);
     router.get("/getCommitmentsByVariableName", service_getCommitmentsByState);
+    // nullifier route
+    router.post("/reinstateNullifiers", service_reinstateNullifiers);
     `;
   }
 };
@@ -850,6 +866,11 @@ zappFilesBoilerplate = () => {
       readPath: pathPrefix + '/api.mjs',
       writePath: './orchestration/api.mjs',
       generic: true,
+    },
+    {
+      readPath: pathPrefix + '/commitment-storage.mjs',
+      writePath: './orchestration/common/commitment-storage.mjs',
+      generic: false,
     },
 ];
 }

--- a/src/codeGenerators/orchestration/files/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/files/toOrchestration.ts
@@ -435,6 +435,13 @@ export default function fileGenerator(node: any) {
       const migrationsfile = files.filter(obj =>
         obj.filepath.includes(`shield`),
       )[0];
+
+      if (node.functionNames.includes('cnstrctr')) {
+        const redeployPath = path.resolve(fileURLToPath(import.meta.url), '../../../../../src/boilerplate/common/bin/redeploy');
+        const redeployFile = { filepath: 'bin/redeploy', file: fs.readFileSync(redeployPath, 'utf8') };
+        prepareSetupScript(redeployFile, node);
+        files.push(redeployFile);
+      }
       // replace placeholder values with ours
       vkfile.file = vkfile.file.replace(
         /FUNCTION_NAMES/g,

--- a/src/transformers/toOrchestration.ts
+++ b/src/transformers/toOrchestration.ts
@@ -63,6 +63,7 @@ export default function toOrchestration(ast: any, options: any) {
   const contractName = `${
     contractNode.name.charAt(0).toUpperCase() + contractNode.name.slice(1)
   }Shield`;
+  const wholeStateNames = contractNode._newASTPointer.wholeNullified;
 
   // copy over existing backend files to the output dir:
   logger.verbose(
@@ -79,6 +80,7 @@ export default function toOrchestration(ast: any, options: any) {
     if (!fileObj.generic) {
       file = file.replace(/CONTRACT_NAME/g, contractName);
       file = file.replace(/FUNCTION_NAME/g, options.zappName);
+      file = file.replace(/WHOLE_STATE_NAMES/g, wholeStateNames ? wholeStateNames.map(n => `'${n}'`).join(', ') : '');
     }
     const dir = pathjs.dirname(filepath);
     logger.debug(`About to save to ${filepath}...`);

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -240,6 +240,7 @@ const visitor = {
 
     exit(path: NodePath, state: any) {
       const { node } = path;
+      node._newASTPointer.wholeNullified = state.wholeNullified;
       for (const file of node._newASTPointer) {
         if (file.nodeType === 'SetupCommonFilesBoilerplate') {
           file.constructorParams = state.constructorParams;
@@ -445,6 +446,11 @@ const visitor = {
               || '';
           }
 
+          if (stateVarIndicator.isWhole && stateVarIndicator.isNullified) {
+            state.wholeNullified ??= [];
+            if (!state.wholeNullified.includes(name)) state.wholeNullified.push(name)
+          }
+          
           let { incrementsArray, incrementsString } = isIncremented
             ? collectIncrements(stateVarIndicator)
             : { incrementsArray: null, incrementsString: null };


### PR DESCRIPTION
When we have a secret state initialised in the constructor, we need a proof and verification. This can make it finicky to redeploy since we must recreate the constructor proof and sync up local dbs before the contract is deployed.
I've added a redeployment script and a short note for users in the readme.

EDIT: ~restart will no longer work for a running zapp since the nullifier state is kept inside the zapp js files (as opposed to a mongo container for commitments, for example)~

UPDATE: Added a `reinstateNullifiers` method for re-adding nullifiers known to the local state, designed to be used after redeploying as above.

To test:

- Zappify a contract with a secret state in the constructor
- Setup and start up as normal
- Down all containers then use the `redeploy` script
- Use `npm restart` for APIs
- Check an ordinary call works