### PR TITLE
zokrates does not like underscores in variable names

### DIFF
--- a/src/transformers/visitors/checks/unsupportedVisitor.ts
+++ b/src/transformers/visitors/checks/unsupportedVisitor.ts
@@ -12,6 +12,16 @@ import { traverseNodesFast } from '../../../traverse/traverse.js';
 
 
 export default {
+  VariableDeclaration: {
+    enter(node: any) {
+      if (node.name?.startsWith('_')) {
+        throw new TODOError(
+          `Variables can have any name which does not start with a number or underscore.`,
+          node,
+        );
+      }
+    },
+  },
   StructuredDocumentation: {
     enter(node: any) {
       throw new TODOError(`Solidity type ${node.nodeType}`, node);


### PR DESCRIPTION
One things we've noticed is that using underscores in Solidity (which is completely valid and very common) does not go well with Zokrates. But the error is less obvious.


```
inomurko@Inos-MacBook-Pro:~$ zokrates compile -i program.zok -o circuit
Compiling program.zok

Compilation failed:

program.zok:
	 --> 1:24
  |
1 | def main(private field _a, private field b) -> field {
  |                        ^---
  |
  = expected _mut or identifier
```

Where program.zok looks like:
```
> cat program.zok

def main(private field _a, private field b) -> field {
    return _a * b;
}
```

So we now detect this early in the original AST:
```
function add(uint256 _asdfasdf) public {
             ^^^^^^^^^^^^^^^^^
[TODOError: TODO: zappify doesn't yet support this feature: Variables can have any name which does not start with a number or underscore.]
```


This might be a long shot - not sure if the fix is in the right place, happy to fix is there's a better approach.

cc @souradeep-das