### PR TITLE
fix: transpilation of public mapping with struct

### DIFF
--- a/src/codeGenerators/contract/solidity/toContract.ts
+++ b/src/codeGenerators/contract/solidity/toContract.ts
@@ -182,6 +182,8 @@ function codeGenerator(node: any) {
       return `${codeGenerator(node.expression)}(${codeGenerator(node.arguments)})`;
 
     case 'UnaryOperation':
+      if (node.operator === '!') return `${node.operator}${codeGenerator(node.subExpression)}`;
+      if (node.prefix === true) return `${node.operator}${codeGenerator(node.subExpression)};`;
       return `${codeGenerator(node.subExpression)} ${node.operator};`;
 
     case 'EmitStatement':

--- a/src/codeGenerators/contract/solidity/toContract.ts
+++ b/src/codeGenerators/contract/solidity/toContract.ts
@@ -108,7 +108,7 @@ function codeGenerator(node: any) {
       if (!node.declarationType && !!node._newASTPointer?.declarationType)
       node.declarationType = node._newASTPointer.declarationType;
       // we crop 'struct ContractName.structname' to just 'structname'
-      if (typeString.includes('struct ')) typeString = typeString.substring(typeString.indexOf(".") + 1);
+      if (typeString.includes('struct ')) typeString = typeString.replace(/struct\s+\w+\./, '');
       typeString = typeString.replace('contract ', ''); // pesky userdefined type 'contract' keword needs to be removed in some cases.
       const constant = node.constant ? ' constant' : '';
       const visibility = node.visibility ? ` ${node.visibility}` : '';


### PR DESCRIPTION
### Overview

1) "Public" solidity mappings that hold "struct" values, are misrepresented while regenerating the contract code

A contract code that includes-
```
mapping (uint256 => Asset) private assetMap;
```
generates a "shield" contract with-
```
Asset) private assetMap;
```
<br>

2) expressions with unary logical not operator (!) are misrepresented
```
require(!varA || !varB);
```
is regenerated to 
```
require(varA !; || varB !;);
```
### Changes

- extended `VariableDeclaration` parsing to also work for 'maps of struct' in addition to struct declarations
- change unary logical not to always prefix
