### PR TITLE
fix: address type public inputs in orchestration scripts

### DIFF
--- a/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
@@ -256,6 +256,7 @@ export function buildBoilerplateNode(nodeType: string, fields: any = {}): any {
         contractName,
         publicInputs = [],
         privateStates = {},
+        publicAddressInputs = [],
       } = fields;
       return {
         nodeType,
@@ -263,6 +264,7 @@ export function buildBoilerplateNode(nodeType: string, fields: any = {}): any {
         functionName,
         contractName,
         publicInputs,
+        publicAddressInputs,
       };
     }
     case 'SetupCommonFilesBoilerplate': {

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -794,7 +794,11 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
           } else if (input.isConstantArray) {
             lines.push(`${input.name}.all.integer`);
           } else {
-            lines.push(`${input}.integer`);
+            if (node.publicAddressInputs.includes(input)) {
+              lines.push(`_${input}`);
+            } else {
+              lines.push(`${input}.integer`);
+            }
           }           
         });
         lines[lines.length - 1] += `, `;

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -601,7 +601,10 @@ const visitor = {
               if (path.isStructDeclaration(param)) newParam.properties = param._newASTPointer.typeName.properties.map(p => p.name);
               if (path.isConstantArray) newParam.isConstantArray = true;
               newNodes.sendTransactionNode.publicInputs.push(newParam);
-            } else newNodes.sendTransactionNode.publicInputs.push(param.name);
+            } else {
+              newNodes.sendTransactionNode.publicInputs.push(param.name);
+              if (param.typeName.name === 'address') newNodes.sendTransactionNode.publicAddressInputs.push(param.name);
+            }
           }
         }
 


### PR DESCRIPTION
#### Overview
'address' type 'public' inputs are sent as integer when sending transaction on-chain

#### Example
```
function callM(secret uin256 a, address b) {}
```
generates

```
// Send transaction to the blockchain:

const txData = await instance.methods
	.initiateForward(
		b.integer,
		...
		..
		proof
	)
	.encodeABI();
```

#### Changes
 - added an additional field to track public 'address' params and form the send transaction accordingly
 
 (not sure if this is the best way, happy to follow your suggestions) 