### PR TITLE
fix error due to redeclarations in zokrates from if statements

### DIFF
--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -243,10 +243,12 @@ function codeGenerator(node: any) {
       }
       // we use our list of condition vars to init temp variables. 
       node.conditionVars.forEach(elt => {
-        let varDec = elt.typeName?.name && (!elt.typeName.name.includes('=> uint256') && elt.typeName.name !== 'uint256') ? elt.typeName.name : 'field';
-        if (elt.isVarDec === false) varDec = '';
-        initialStatements += `
+        if (elt.nodeType !== 'IndexAccess' || (elt.indexExpression && elt.indexExpression.nodeType === 'MsgSender')){
+          let varDec = elt.typeName?.name && (!elt.typeName.name.includes('=> uint256') && elt.typeName.name !== 'uint256') ? elt.typeName.name : 'field';
+          if (elt.isVarDec === false) varDec = '';
+          initialStatements += `
         ${varDec} ${codeGenerator(elt)}_temp = ${codeGenerator(elt)}`;
+        }
       });
       for (let i =0; i<node.trueBody.length; i++) {
         trueStatements+= `

--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -241,10 +241,12 @@ function codeGenerator(node: any) {
       assert(${codeGenerator(node.condition)})`;
       return initialStatements;
       }
-      // we use our list of condition vars to init temp variables
+      // we use our list of condition vars to init temp variables. 
       node.conditionVars.forEach(elt => {
+        let varDec = elt.typeName?.name && (!elt.typeName.name.includes('=> uint256') && elt.typeName.name !== 'uint256') ? elt.typeName.name : 'field';
+        if (elt.isVarDec === false) varDec = '';
         initialStatements += `
-        ${elt.typeName?.name && (!elt.typeName.name.includes('=> uint256') && elt.typeName.name !== 'uint256') ? elt.typeName.name : 'field'} ${codeGenerator(elt)}_temp = ${codeGenerator(elt)}`;
+        ${varDec} ${codeGenerator(elt)}_temp = ${codeGenerator(elt)}`;
       });
       for (let i =0; i<node.trueBody.length; i++) {
         trueStatements+= `


### PR DESCRIPTION
A temporary variable is created for a secret state variable if it appears in an If Statement. Multiple if statements were causing the temporary variable to be declared twice in the Zokrates circuit file leading to an error. 