### PR TITLE
split commitment Function

### DIFF
--- a/circuits/common/joinCommitments.zok
+++ b/circuits/common/joinCommitments.zok
@@ -22,7 +22,7 @@ def main(\
   public field nullifierRoot,\
   public field newNullifierRoot,\
 	public field oldCommitment_0_nullifier,\
-  public field[32] oldCommitment_0_nullifier_nonmembershipWitness_siblingPath,\
+  private field[32] oldCommitment_0_nullifier_nonmembershipWitness_siblingPath,\
   private field[32] oldCommitment_0_nullifier_nonmembershipWitness_newsiblingPath,\
 	public field oldCommitment_1_nullifier,\
   private field[32] oldCommitment_1_nullifier_nonmembershipWitness_siblingPath,\

--- a/circuits/common/splitCommitments.zok
+++ b/circuits/common/splitCommitments.zok
@@ -31,7 +31,7 @@ def main(\
 	private field[32] oldCommitment_0_membershipWitness_siblingPath,\
 	private field newCommitment_0_owner_publicKey_field,\
 	private field newCommitment_0_salt_field,\
-	public field newCommitment_0_commitment\
+	public field newCommitment_0_commitment,\
     private field newCommitment_1_owner_publicKey_field,\
 	private field newCommitment_1_salt_field,\
 	public field newCommitment_1_commitment\

--- a/circuits/common/splitCommitments.zok
+++ b/circuits/common/splitCommitments.zok
@@ -1,0 +1,141 @@
+from "ecc/babyjubjubParams" import main as curveParams
+from "ecc/edwardsScalarMult" import main as scalarMult
+from "ecc/edwardsCompress" import main as edwardsCompress
+from "utils/pack/u32/nonStrictUnpack256.zok" import main as field_to_u32_8
+from "hashes/sha256/sha256Padded.zok" import sha256Padded as sha256Padded
+from "./common/hashes/mimc/altbn254/mimc2.zok" import main as mimc2
+from "utils/pack/bool/nonStrictUnpack256.zok" import main as field_to_bool_256
+from "utils/casts/u32_8_to_bool_256.zok" import main as u32_8_to_bool_256
+from "./common/hashes/poseidon/poseidon.zok" import main as poseidon
+from "./common/casts/u32_array_to_field.zok" import main as u32_array_to_field
+from "utils/pack/bool/pack256.zok" import main as bool_256_to_field
+from "./common/merkle-tree/mimc/altbn254/verify-membership/height32.zok" import main as checkRoot
+from "./common/merkle-tree/sparse-merkle-tree/checkproof.zok" import checkUpdatedPath as checkUpdatedPath
+from "./common/merkle-tree/sparse-merkle-tree/checkproof.zok" import main as checkproof
+
+def main(\
+    private field value,\
+	private field fromId,\
+	private field stateVarId,\
+	private bool isMapping,\
+	private field oldCommitment_0_owner_secretKey_field,\
+    public field nullifierRoot,\
+    public field newNullifierRoot,\
+	public field oldCommitment_0_nullifier,\
+    public field[32] oldCommitment_0_nullifier_nonmembershipWitness_siblingPath,\
+    private field[32] oldCommitment_0_nullifier_nonmembershipWitness_newsiblingPath,\
+	private field oldCommitment_0_value,\
+	private field oldCommitment_0_salt_field,\
+	public field commitmentRoot,\
+	private field oldCommitment_0_membershipWitness_index,\
+	private field[32] oldCommitment_0_membershipWitness_siblingPath,\
+	private field newCommitment_0_owner_publicKey_field,\
+	private field newCommitment_0_salt_field,\
+	public field newCommitment_0_commitment\
+    private field newCommitment_1_owner_publicKey_field,\
+	private field newCommitment_1_salt_field,\
+	public field newCommitment_1_commitment\
+) -> (bool) :
+
+// check if state is mapping or not
+
+        field oldCommitment_0_stateVarId_field =  if isMapping == true then mimc2([stateVarId, fromId]) else stateVarId fi
+
+
+        field newCommitment_stateVarId_field = if isMapping == true then mimc2([stateVarId, fromId]) else stateVarId fi
+
+
+        u32[8] newCommitment_stateVarId = field_to_u32_8(newCommitment_stateVarId_field)
+
+
+		field oldCommitment_0 = oldCommitment_0_value
+
+        // oldCommitment_0 - PoKoSK:
+        // The correctness of this secret key will be constrained within the oldCommitment existence check.
+
+        field[2] oldCommitment_0_owner_publicKey_point = scalarMult(field_to_bool_256(oldCommitment_0_owner_secretKey_field), [curveParams().Gu, curveParams().Gv], curveParams())
+
+		bool oldCommitment_0_owner_publicKey_sign = edwardsCompress(oldCommitment_0_owner_publicKey_point)[0]
+
+		bool[254] yBits = field_to_bool_256(oldCommitment_0_owner_publicKey_point[1])[2..256]
+		yBits[0] = oldCommitment_0_owner_publicKey_sign
+
+		field oldCommitment_0_owner_publicKey_field = bool_256_to_field([false, false, ...yBits])
+
+        // Nullify oldCommitment_0:
+
+        field oldCommitment_0_nullifier_check_field = poseidon([\
+          oldCommitment_0_stateVarId_field,\
+          oldCommitment_0_owner_secretKey_field,\
+          oldCommitment_0_salt_field\
+        ])
+
+        assert(\
+        field_to_bool_256(oldCommitment_0_nullifier)[8..256] == field_to_bool_256(oldCommitment_0_nullifier_check_field)[8..256]\
+        )
+       
+       assert(\
+          nullifierRoot == checkproof(\
+            oldCommitment_0_nullifier_nonmembershipWitness_siblingPath,\
+            oldCommitment_0_nullifier\
+           )          )
+
+        assert( newNullifierRoot == checkUpdatedPath(oldCommitment_0_nullifier_nonmembershipWitness_newsiblingPath,\
+         oldCommitment_0_nullifier)  )
+  
+        // oldCommitment_0_commitment: preimage check
+
+        field oldCommitment_0_commitment_field = poseidon([\
+          oldCommitment_0_stateVarId_field,\
+          oldCommitment_0,\
+          oldCommitment_0_owner_publicKey_field,\
+          oldCommitment_0_salt_field\
+        ])
+
+        // oldCommitment_0_commitment: existence check
+
+        field oldCommitment_0_commitmentRoot_check = checkRoot(\
+          oldCommitment_0_membershipWitness_siblingPath,\
+          oldCommitment_0_commitment_field,\
+          oldCommitment_0_membershipWitness_index\
+        )
+
+
+        assert(\
+          field_to_bool_256(commitmentRoot)[8..256] == field_to_bool_256(oldCommitment_0_commitmentRoot_check)[8..256]\
+        )
+
+
+        // prepare secret state 'newCommitments' for commitments
+
+
+
+	  field newCommitment_0_value_field =   value
+      field newCommitment_1_value_field =   oldCommitment_0_value - value
+        //  preimage check - newCommitment_commitment
+
+        field newCommitment_0_commitment_check_field = poseidon([\
+          newCommitment_stateVarId_field,\
+          newCommitment_0_value_field,\
+          newCommitment_0_owner_publicKey_field,\
+          newCommitment_0_salt_field\
+        ])
+
+        assert(\
+          field_to_bool_256(newCommitment_0_commitment)[8..256] == field_to_bool_256(newCommitment_0_commitment_check_field)[8..256]\
+        )
+
+        //  preimage check - newCommitment_commitment
+
+        field newCommitment_1_commitment_check_field = poseidon([\
+          newCommitment_stateVarId_field,\
+          newCommitment_1_value_field,\
+          newCommitment_1_owner_publicKey_field,\
+          newCommitment_1_salt_field\
+        ])
+
+        assert(\
+          field_to_bool_256(newCommitment_1_commitment)[8..256] == field_to_bool_256(newCommitment_1_commitment_check_field)[8..256]\
+        )
+
+        return true

--- a/circuits/common/splitCommitments.zok
+++ b/circuits/common/splitCommitments.zok
@@ -22,7 +22,7 @@ def main(\
     public field nullifierRoot,\
     public field newNullifierRoot,\
 	public field oldCommitment_0_nullifier,\
-    public field[32] oldCommitment_0_nullifier_nonmembershipWitness_siblingPath,\
+    private field[32] oldCommitment_0_nullifier_nonmembershipWitness_siblingPath,\
     private field[32] oldCommitment_0_nullifier_nonmembershipWitness_newsiblingPath,\
 	private field oldCommitment_0_value,\
 	private field oldCommitment_0_salt_field,\

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -680,7 +680,7 @@ export async function splitCommitments(
     .splitCommitments(
       oldCommitment_nullifierRoot.integer,
       oldCommitment_newNullifierRoot.integer,
-      [oldCommitment_0_nullifier.integer.integer],
+      [oldCommitment_0_nullifier.integer],
       oldCommitment_root.integer,
       [newCommitment_0.integer, newCommitment_1.integer],
       proof,

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -10,12 +10,7 @@ import logger from './logger.mjs';
 import utils from 'zkp-utils';
 import { poseidonHash } from './number-theory.mjs';
 import { generateProof } from './zokrates.mjs';
-import {
-  SumType,
-  reduceTree,
-  toBinArray,
-  poseidonConcatHash,
-} from './smt_utils.mjs';
+import { SumType, reduceTree, toBinArray, poseidonConcatHash } from './smt_utils.mjs';
 import { hlt } from './hash-lookup.mjs';
 
 const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION } = config;
@@ -213,7 +208,6 @@ export async function markNullified(commitmentHash, secretKey = null) {
 }
 
 export function getInputCommitments(
-  contractName,
   publicKey,
   value,
   commitments,
@@ -555,7 +549,7 @@ export async function splitCommitments(
 
   // Extract set membership witness:
 
-  const oldCommitment_0_witness = witnesses;
+  const oldCommitment_0_witness = witness;
 
   const oldCommitment_0_index = generalise(oldCommitment_0_witness.index);
   const oldCommitment_root = generalise(oldCommitment_0_witness.root);
@@ -623,11 +617,12 @@ export async function splitCommitments(
     BigInt(newCommitment_0_newSalt.hex(32)),
   ]);
 
-  newCommitment_1 = generalise(newCommitment_1.hex(32)); // truncate
+  newCommitment_0 = generalise(newCommitment_0.hex(32)); // truncate
 
   const newCommitment_1_newSalt = generalise(utils.randomHex(31));
 
-  let newCommitment_1_value = parseInt(oldCommitment_0_prev.integer, 10) - parseInt(value.integer, 10);
+  let newCommitment_1_value =
+    parseInt(oldCommitment_0_prev.integer, 10) - parseInt(value.integer, 10);
 
   newCommitment_1_value = generalise(newCommitment_1_value);
 

--- a/src/boilerplate/contract/solidity/nodes/ContractBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/nodes/ContractBoilerplateGenerator.ts
@@ -57,6 +57,8 @@ class ContractBoilerplateGenerator {
         'verify',
         'joinCommitmentsFunction',
         'joinCommitmentsCircuitName',
+        'splitCommitmentsFunction',
+        'splitCommitmentsCircuitName',
       ];
     },
 
@@ -69,10 +71,10 @@ class ContractBoilerplateGenerator {
 
     stateVariableDeclarations() {
       const { scope } = this;
-      let isjoinCommitmentsFunction : string[]=[];
+      let isjoinSplitCommitmentsFunction : string[]=[];
       for(const [, binding ] of Object.entries(scope.bindings)){
        if((binding instanceof VariableBinding) && binding.isPartitioned && binding.isNullified && !binding.isStruct )
-          isjoinCommitmentsFunction?.push('true');
+          isjoinSplitCommitmentsFunction?.push('true');
       }
       let {
         indicators: { nullifiersRequired, oldCommitmentAccessRequired, newCommitmentsRequired, containsAccessedOnlyState, encryptionRequired },
@@ -81,8 +83,8 @@ class ContractBoilerplateGenerator {
         (b: any) => b.kind === 'FunctionDefinition' && b.path.containsSecret,
       );
       let functionNames = Object.values(fnDefBindings).map((b: any) => b.path.getUniqueFunctionName());
-      if (isjoinCommitmentsFunction.includes('true')) { 
-        functionNames.push('joinCommitments')
+      if (isjoinSplitCommitmentsFunction.includes('true')) { 
+        functionNames.push('joinCommitments', 'splitCommitments');
         nullifiersRequired = true;
         oldCommitmentAccessRequired = true;
       }
@@ -107,10 +109,10 @@ class ContractBoilerplateGenerator {
       let {
         indicators: { nullifiersRequired, oldCommitmentAccessRequired, newCommitmentsRequired, containsAccessedOnlyState, encryptionRequired },
       } = this.scope;
-      let isjoinCommitmentsFunction : string[]=[];
+      let isjoinSplitCommitmentsFunction : string[]=[];
       for(const [, binding ] of Object.entries(this.scope.bindings)){
        if((binding instanceof VariableBinding) && binding.isPartitioned && binding.isNullified && !binding.isStruct)
-          isjoinCommitmentsFunction?.push('true');
+          isjoinSplitCommitmentsFunction?.push('true');
       }
       let parameterList: any[];
       let paramtype: string;
@@ -176,7 +178,7 @@ class ContractBoilerplateGenerator {
      circuitParams[ functionName ] = parameterList;
     }
       const constructorContainsSecret = Object.values(this.scope.bindings).some((binding: any) => binding.node.kind === 'constructor')
-      return { nullifiersRequired, oldCommitmentAccessRequired, newCommitmentsRequired, containsAccessedOnlyState, encryptionRequired, constructorContainsSecret, circuitParams, isjoinCommitmentsFunction};
+      return { nullifiersRequired, oldCommitmentAccessRequired, newCommitmentsRequired, containsAccessedOnlyState, encryptionRequired, constructorContainsSecret, circuitParams, isjoinSplitCommitmentsFunction};
     },
 
   };

--- a/src/boilerplate/contract/solidity/raw/ContractBoilerplateGenerator.ts
+++ b/src/boilerplate/contract/solidity/raw/ContractBoilerplateGenerator.ts
@@ -109,7 +109,7 @@ class ContractBoilerplateGenerator {
       encryptionRequired,
       circuitParams,
       constructorContainsSecret,
-      isjoinCommitmentsFunction,
+      isjoinSplitCommitmentsFunction,
     }): string[] {
       const verifyFunctionSignature = `
         function verify(
@@ -207,7 +207,7 @@ class ContractBoilerplateGenerator {
 
       ];
       const verifyInputs: string[] = [];
-      const joinCommitmentsInputs: string[] = [];
+      const joinSplitCommitmentsInputs: string[] = [];
       for (let [name, _params] of Object.entries(circuitParams)) {
         if (_params) 
           for (let [type, _inputs] of Object.entries(_params)) {
@@ -262,9 +262,9 @@ class ContractBoilerplateGenerator {
       }`] : [] 
       ];
 
-      if (isjoinCommitmentsFunction?.includes('true')) {
+      if (isjoinSplitCommitmentsFunction?.includes('true')) {
 
-       joinCommitmentsInputs.push(
+       joinSplitCommitmentsInputs.push(
         `
            function joinCommitments(uint256 nullifierRoot, uint256 latestNullifierRoot, uint256[] calldata newNullifiers,  uint256 commitmentRoot, uint256[] calldata newCommitments, uint256[] calldata proof) public {
 
@@ -284,7 +284,27 @@ class ContractBoilerplateGenerator {
             inputs.newCommitments = newCommitments;
 
             verify(proof, uint(FunctionNames.joinCommitments), inputs);
-        }`)
+        }
+        
+        function splitCommitments(uint256 nullifierRoot, uint256 latestNullifierRoot, uint256[] calldata newNullifiers,  uint256 commitmentRoot, uint256[] calldata newCommitments, uint256[] calldata proof) public {
+
+          Inputs memory inputs;
+
+          inputs.customInputs = new uint[](1);
+          inputs.customInputs[0] = 1;
+
+          inputs.nullifierRoot = nullifierRoot;
+
+          inputs.latestNullifierRoot = latestNullifierRoot;
+
+          inputs.newNullifiers = newNullifiers;
+
+          inputs.commitmentRoot = commitmentRoot;
+
+          inputs.newCommitments = newCommitments;
+
+          verify(proof, uint(FunctionNames.splitCommitments), inputs);
+      }`)
        verifyInputs.push(`
 
          if (functionId == uint(FunctionNames.joinCommitments)) {
@@ -302,6 +322,23 @@ class ContractBoilerplateGenerator {
            inputs[k++] = newCommitments[0];
            inputs[k++] = 1;
                 
+         }
+         
+         if (functionId == uint(FunctionNames.splitCommitments)) {
+
+          
+          require(newNullifierRoot == _inputs.nullifierRoot, "Input NullifierRoot does not exist.");
+
+           uint k = 0;
+
+           inputs[k++] = _inputs.nullifierRoot;
+           inputs[k++] = _inputs.latestNullifierRoot;
+           inputs[k++] = newNullifiers[0];
+           inputs[k++] = _inputs.commitmentRoot;
+           inputs[k++] = newCommitments[0];
+           inputs[k++] = newCommitments[1];
+           inputs[k++] = 1;
+                
          }`)
 
        }
@@ -312,7 +349,7 @@ class ContractBoilerplateGenerator {
           ${verifyInputs.join('\n')}
           ${verification.join('\n')}
         }`,
-        `${joinCommitmentsInputs}`
+        `${joinSplitCommitmentsInputs}`
       ];
 
 

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -167,7 +167,7 @@ class BoilerplateGenerator {
 
             if(${stateName}_1_oldCommitment === null && ${stateName}_commitmentFlag){
               \n${stateName}_witness_0 = await getMembershipWitness('${contractName}', generalise(${stateName}_0_oldCommitment._id).integer);
-               \n const tx = await splitCommitments('${contractName}', '${mappingName}', ${stateName}_newCommitmentValue.integer, secretKey, publicKey, [${stateVarId.join(' , ')}], ${stateName}_0_oldCommitment, ${stateName}_witness_0, instance, contractAddr, web3);
+               \n const tx = await splitCommitments('${contractName}', '${mappingName}', ${stateName}_newCommitmentValue, secretKey, publicKey, [${stateVarId.join(' , ')}], ${stateName}_0_oldCommitment, ${stateName}_witness_0, instance, contractAddr, web3);
                ${stateName}_preimage = await getCommitmentsById(${stateName}_stateVarId);
 
                [${stateName}_commitmentFlag, ${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment] = getInputCommitments(

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -165,6 +165,18 @@ class BoilerplateGenerator {
             \nlet ${stateName}_witness_0;
             \nlet ${stateName}_witness_1;
 
+            if(${stateName}_1_oldCommitment === null && ${stateName}_commitmentFlag){
+              \n${stateName}_witness_0 = await getMembershipWitness('${contractName}', generalise(${stateName}_0_oldCommitment._id).integer);
+               \n const tx = await splitCommitments('${contractName}', '${mappingName}', ${stateName}_newCommitmentValue.integer, secretKey, publicKey, [${stateVarId.join(' , ')}], ${stateName}_0_oldCommitment, ${stateName}_witness_0, instance, contractAddr, web3);
+               ${stateName}_preimage = await getCommitmentsById(${stateName}_stateVarId);
+
+               [${stateName}_commitmentFlag, ${stateName}_0_oldCommitment, ${stateName}_1_oldCommitment] = getInputCommitments(
+                publicKey.hex(32),
+                ${stateName}_newCommitmentValue.integer,
+                ${stateName}_preimage,
+              );
+            }
+
             while(${stateName}_commitmentFlag === false) {
                 \n${stateName}_witness_0 = await getMembershipWitness('${contractName}', generalise(${stateName}_0_oldCommitment._id).integer);
                 \n${stateName}_witness_1 = await getMembershipWitness('${contractName}', generalise(${stateName}_1_oldCommitment._id).integer);
@@ -405,7 +417,7 @@ class BoilerplateGenerator {
         `\nimport fs from 'fs';
         \n`,
         `\nimport { getContractInstance, getContractAddress, registerKey } from './common/contract.mjs';`,
-        `\nimport { storeCommitment, getCurrentWholeCommitment, getCommitmentsById, getAllCommitments, getInputCommitments, joinCommitments, markNullified,getnullifierMembershipWitness,getupdatedNullifierPaths,temporaryUpdateNullifier,updateNullifierTree } from './common/commitment-storage.mjs';`,
+        `\nimport { storeCommitment, getCurrentWholeCommitment, getCommitmentsById, getAllCommitments, getInputCommitments, joinCommitments, splitCommitments, markNullified,getnullifierMembershipWitness,getupdatedNullifierPaths,temporaryUpdateNullifier,updateNullifierTree } from './common/commitment-storage.mjs';`,
         `\nimport { generateProof } from './common/zokrates.mjs';`,
         `\nimport { getMembershipWitness, getRoot } from './common/timber.mjs';`,
         `\nimport Web3 from './common/web3.mjs';`,

--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -53,6 +53,9 @@ function codeGenerator(node: any) {
       if (!file && node.fileName === `joinCommitments`) {
         thisFile.file = fs.readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../../../../circuits/common/joinCommitments.zok'), 'utf8');
       }
+      if (!file && node.fileName === `splitCommitments`) {
+        thisFile.file = fs.readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../../../../circuits/common/splitCommitments.zok'), 'utf8');
+      }
       const importedFiles = collectImportFiles(thisFile.file, 'circuit');
       return [thisFile, ...importedFiles];
     }
@@ -197,6 +200,8 @@ function codeGenerator(node: any) {
     }
     case 'JoinCommitmentFunctionDefinition' :
     return `${CircuitBP.uniqueify(node.body.statements.flatMap(codeGenerator)).join('\n')}`;
+    case 'SplitCommitmentFunctionDefinition' :
+      return `${CircuitBP.uniqueify(node.body.statements.flatMap(codeGenerator)).join('\n')}`;
     case 'Return':
       return  ` ` ;
 

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -176,13 +176,13 @@ const visitor = {
 
 
       const joinCommitmentsNode = buildNode('File', {
-       fileName: `joinSplitCommitments`,
+       fileName: `joinCommitments`,
         fileId: node.id,
         nodes: [ ],
       });
 
       const splitCommitmentsNode = buildNode('File', {
-        fileName: `spiltCommitments`,
+        fileName: `splitCommitments`,
          fileId: node.id,
          nodes: [ ],
        });

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -176,18 +176,27 @@ const visitor = {
 
 
       const joinCommitmentsNode = buildNode('File', {
-       fileName: `joinCommitments`,
+       fileName: `joinSplitCommitments`,
         fileId: node.id,
         nodes: [ ],
       });
 
-      // check for joinCommitments
+      const splitCommitmentsNode = buildNode('File', {
+        fileName: `spiltCommitments`,
+         fileId: node.id,
+         nodes: [ ],
+       });
+
+      // check for joinCommitments and splitCommitments
       for(const [, indicator ] of Object.entries(indicators)){
         if((indicator instanceof StateVariableIndicator)
           && indicator.isPartitioned
           && indicator.isNullified && !indicator.isStruct) {
             if (!parent._newASTPointer.some(n => n.fileName === joinCommitmentsNode.fileName)){
               parent._newASTPointer.push(joinCommitmentsNode);
+            }
+            if (!parent._newASTPointer.some(n => n.fileName === splitCommitmentsNode.fileName)){
+              parent._newASTPointer.push(splitCommitmentsNode);
             }
         }
         if(indicator instanceof StateVariableIndicator && indicator.encryptionRequired) {

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -245,8 +245,9 @@ const visitor = {
         if (file.nodeType === 'SetupCommonFilesBoilerplate') {
           file.constructorParams = state.constructorParams;
           file.contractImports = state.contractImports;
-          if(state.isjoinCommitmentsFunction?.includes('true'))
+          if(state.isjoinSplitCommitmentsFunction?.includes('true'))
             file.functionNames.push('joinCommitments');
+            file.functionNames.push('splitCommitments');
         }
         if (file.nodes?.[0].nodeType === 'IntegrationTestBoilerplate') {
           file.nodes[0].constructorParams = state.constructorParams;
@@ -354,8 +355,8 @@ const visitor = {
           indicators.isPartitioned &&
           !indicators.isStruct &&
           indicators.isNullified ) {
-           state.isjoinCommitmentsFunction ??= [];
-           state.isjoinCommitmentsFunction?.push('true');
+           state.isjoinSplitCommitmentsFunction ??= [];
+           state.isjoinSplitCommitmentsFunction?.push('true');
          }
       }
 

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -245,9 +245,11 @@ const visitor = {
         if (file.nodeType === 'SetupCommonFilesBoilerplate') {
           file.constructorParams = state.constructorParams;
           file.contractImports = state.contractImports;
-          if(state.isjoinSplitCommitmentsFunction?.includes('true'))
+          if(state.isjoinSplitCommitmentsFunction?.includes('true')){
             file.functionNames.push('joinCommitments');
             file.functionNames.push('splitCommitments');
+          }
+            
         }
         if (file.nodes?.[0].nodeType === 'IntegrationTestBoilerplate') {
           file.nodes[0].constructorParams = state.constructorParams;

--- a/test/real-world-zapps/Escrow.zol
+++ b/test/real-world-zapps/Escrow.zol
@@ -11,8 +11,8 @@ contract Escrow {
     secret mapping(address => uint256) public balances;
     IERC20 public erc20;
 
-    constructor(address _erc20) {
-        erc20 = IERC20(_erc20);
+    constructor(address erc20Address) {
+        erc20 = IERC20(erc20Address);
     }
 
     function deposit(uint256 amount) public {


### PR DESCRIPTION
This PR adds the code for split commitment function, currently when we have a partitioned state, we require two commitment in, to decrement that state. With this code, if you have a commitment with sufficient balance, it splits that commitment into two, so the user is not forced to add a new commitment to use his balance.
