### PR TITLE
Changes zok img in docker compose

### DIFF
--- a/src/boilerplate/common/boilerplate-docker-compose.yml
+++ b/src/boilerplate/common/boilerplate-docker-compose.yml
@@ -53,7 +53,9 @@ services:
       - zapp_network
 
   zokrates:
-    image: ghcr.io/eyblockchain/zokrates-worker-starlight:v0.2
+    image: ghcr.io/eyblockchain/zokrates-worker-updated:latest
+    # the following image is for arm64 architecture. Uncomment the following lines and comment the above line if you are using ARM
+    # image: ghcr.io/eyblockchain/zokrates-worker-starlight:v0.2
     # platform: linux/arm64/v8
     volumes:
       - ./circuits/:/app/circuits:delegated


### PR DESCRIPTION
This PR introduces a change to use another docker image for Zokrates, since `ghcr.io/eyblockchain/zokrates-worker-starlight:v0.2` was targeting ARM envs only. The new image is targeting AMD64 platforms, but we leave the former url commented out for those using ARM.