### PR TITLE
bumps node version on Dockerfiles

### DIFF
--- a/src/boilerplate/common/boilerplate-Dockerfile
+++ b/src/boilerplate/common/boilerplate-Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17
+FROM node:18.19
 
 WORKDIR /app
 

--- a/src/boilerplate/common/boilerplate-Dockerfile.deployer
+++ b/src/boilerplate/common/boilerplate-Dockerfile.deployer
@@ -1,4 +1,4 @@
-FROM node:16.17
+FROM node:18.19
 
 WORKDIR /app
 


### PR DESCRIPTION
changing node version from 16 to 18, because v16 is not maintained anymore.