### PR TITLE
chore: hoisting npm ci

### DIFF
--- a/src/boilerplate/common/boilerplate-Dockerfile
+++ b/src/boilerplate/common/boilerplate-Dockerfile
@@ -4,5 +4,13 @@ WORKDIR /app
 
 
 COPY ./package.json ./package-lock.json ./
-RUN npm ci
+RUN npm i
+COPY circuits ./circuits
+COPY config ./config
+COPY build/contracts ./build/contracts
+COPY orchestration ./orchestration
+COPY proving-files ./proving-files
+
 EXPOSE 3000
+
+CMD ["node", "orchestration/api.mjs"]

--- a/src/boilerplate/common/boilerplate-Dockerfile.deployer
+++ b/src/boilerplate/common/boilerplate-Dockerfile.deployer
@@ -6,10 +6,10 @@ RUN apt-get update -y
 RUN apt-get install -y netcat-openbsd
 
 COPY ./package.json ./package-lock.json ./
+RUN npm ci
 COPY entrypoint.sh entrypoint.sh
 COPY contracts contracts
 COPY migrations migrations
 COPY truffle-config.js truffle-config.js
 RUN chmod +x entrypoint.sh
-RUN npm ci
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
This PR introduces two changes into the boilerplate-Dockerfiles:

1 - moves the line "RUN npm ci" closer to the package.json copy, so we can cache it before edits in the  code
2 - Copies circuits, config, build/contracts, orchestration and proving-files into zapp's container, and starts the webserver by default when user starts the zapp service.

Solves #251 