### PR TITLE
fix: remove unnecessary generalizations in orchestration

### DIFF
--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -316,8 +316,14 @@ const internalCallVisitor = {
                             }
                            });
                           childNode.body.statements[id-1].initialValue =undefined;
+                          } else{
+                            node.body.statements.forEach(kidNode =>{
+                              if(kidNode.nodeType === 'ExpressionStatement'&& kidNode.expression.name === state.internalFncName[index]) {
+                                 kidNode.expression = Object.assign(kidNode.expression,statenode.expression);
+                              }
+                             });
                           }
-                        }
+                        } 
                        });
                       });
                       // remove multiple variable declarations

--- a/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
+++ b/src/transformers/visitors/orchestrationInternalFunctionCallVisitor.ts
@@ -304,7 +304,38 @@ const internalCallVisitor = {
                         }
                       });
                       childNode.body.statements = childNode.body.statements.filter(item => item !== null && item !== undefined);
-                     } else{
+                     } else if (state.callingFncName[index].parent === 'ForStatement'){
+                       state.newStatementList.forEach((statenode, stateid) => {
+                        childNode.body.statements.forEach((node, id)=> {
+                         if(node.nodeType === state.callingFncName[index].parent){
+                          if(statenode.nodeType === 'VariableDeclarationStatement'){
+                            childNode.body.statements[id-1] = statenode;
+                           node.body.statements.forEach(kidNode =>{
+                            if(kidNode.nodeType === 'ExpressionStatement'&& kidNode.expression.name === state.internalFncName[index]) {
+                               kidNode.expression = Object.assign(kidNode.expression,statenode.initialValue);
+                            }
+                           });
+                          childNode.body.statements[id-1].initialValue =undefined;
+                          }
+                        }
+                       });
+                      });
+                      // remove multiple variable declarations
+                      childNode.body.statements.forEach((node1, index1)=> {
+                        let isDecDeleted = false;
+                        if(node1.nodeType === 'VariableDeclarationStatement'){
+                         childNode.body.statements.forEach((node2, index2)=> {
+                           if(!isDecDeleted && index2 < index1 && node2 && node2.nodeType === 'VariableDeclarationStatement'){
+                             if ((node1.declarations[0].name === node2.declarations[0].name)){
+                               childNode.body.statements.splice(index1, 1, node1.initialValue);
+                               isDecDeleted = true;
+                             }
+                           }
+                         });
+                       }
+                     });
+                     childNode.body.statements = childNode.body.statements.filter(item => item !== null && item !== undefined );
+                     } else {
                        state.newStatementList.forEach((statenode, stateid) => {
                         childNode.body.statements.forEach((node, id)=> {
                          if(node.nodeType === state.callingFncName[index].parent){

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1295,11 +1295,6 @@ const visitor = {
       if (node._newASTPointer?.interactsWithSecret && path.getAncestorOfType('ForStatement'))  {
         path.getAncestorOfType('ForStatement').node._newASTPointer.interactsWithSecret = true;
         if(indicator){
-          console.log(buildNode('Assignment', {
-            leftHandSide: buildNode('Identifier', { name }),
-            operator: '=',
-            rightHandSide: buildNode('Identifier', {  name, subType: 'generalNumber'})
-          }));
           path.getAncestorOfType('Block')?.node._newASTPointer.push(
             buildNode('Assignment', {
               leftHandSide: buildNode('Identifier', { name }),

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1290,23 +1290,16 @@ const visitor = {
       if (node._newASTPointer?.incrementsSecretState && indicator) {
         const increments = collectIncrements(indicator).incrementsString;
         path.node._newASTPointer.increments = increments;
-      } else if (indicator?.isWhole && node._newASTPointer) {
-        // we add a general number statement after each whole state edit
-        const tempNode = node._newASTPointer;
-        name = tempNode.initialValue && tempNode.initialValue.leftHandSide ? tempNode.initialValue.leftHandSide.name : name;
-        if (node._newASTPointer.interactsWithSecret) path.getAncestorOfType('FunctionDefinition')?.node._newASTPointer.body.statements.push(
-          buildNode('Assignment', {
-              leftHandSide: buildNode('Identifier', { name }),
-              operator: '=',
-              rightHandSide: buildNode('Identifier', { name, subType: 'generalNumber' })
-            }
-          )
-        );
-      }
+      } 
 
       if (node._newASTPointer?.interactsWithSecret && path.getAncestorOfType('ForStatement'))  {
         path.getAncestorOfType('ForStatement').node._newASTPointer.interactsWithSecret = true;
         if(indicator){
+          console.log(buildNode('Assignment', {
+            leftHandSide: buildNode('Identifier', { name }),
+            operator: '=',
+            rightHandSide: buildNode('Identifier', {  name, subType: 'generalNumber'})
+          }));
           path.getAncestorOfType('Block')?.node._newASTPointer.push(
             buildNode('Assignment', {
               leftHandSide: buildNode('Identifier', { name }),

--- a/test/contracts/If-Statement5.zol
+++ b/test/contracts/If-Statement5.zol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: CC0
+ 
+pragma solidity ^0.8.0;
+ 
+contract Assign {
+ 
+  secret uint256 private a;
+ 
+  uint256[5] public b;
+ 
+ 
+  function add(secret uint256[5] calldata value, uint256[5] calldata publicValue) public {
+    b = publicValue;
+    for (uint256 index = 0; index < 5; index++) {
+      if(value[index] > 10){
+      known a += value[index];
+      } else {
+         a = 2*value[index] + 1;
+      }
+    }
+  }
+ 
+  function remove(secret uint256 value) public {
+    a -= value;
+  }
+}
+ 

--- a/test/contracts/for-InternalFunctionCall.zol
+++ b/test/contracts/for-InternalFunctionCall.zol
@@ -15,5 +15,6 @@ contract Assign {
   }
   function add(secret uint256 value) public {
     known a += value;
+    //a += 1;
   }
 }

--- a/test/contracts/for-InternalFunctionCall.zol
+++ b/test/contracts/for-InternalFunctionCall.zol
@@ -15,6 +15,6 @@ contract Assign {
   }
   function add(secret uint256 value) public {
     known a += value;
-    //a += 1;
+    a += 1;
   }
 }

--- a/test/contracts/generalise.zol
+++ b/test/contracts/generalise.zol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+contract SyntheticPpa {
+    secret uint256 private a;
+    address public immutable owner;
+    secret mapping(uint256 => uint256) private b;
+    secret mapping(uint256 => uint256) private c;
+
+    struct myStruct {
+        uint256 prop1;
+        uint256 prop2;
+        uint256 prop3;
+    }
+    secret myStruct private d;
+
+
+    modifier onlyOwner() {
+        require(
+            msg.sender == owner
+        );
+        _;
+    }
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+
+    function add(secret uint256 value, secret uint256 index) public onlyOwner {
+        a = value;
+        if (a > 5) {
+            b[index] = a;
+        } else {
+            c[index] = a +3;
+        }
+        secret uint256 index1 = 0;
+        if (c[index] > 0) { 
+            d.prop1 = value;
+            d.prop2 = value +1;
+            d.prop3 = value +2;
+        } 
+    }
+
+
+
+
+
+    
+}

--- a/test/contracts/generalise.zol
+++ b/test/contracts/generalise.zol
@@ -34,7 +34,6 @@ contract SyntheticPpa {
         } else {
             c[index] = a +3;
         }
-        secret uint256 index1 = 0;
         if (c[index] > 0) { 
             d.prop1 = value;
             d.prop2 = value +1;


### PR DESCRIPTION
Remove unnecessary generalisation in orchestration. After each secret whole edit, previously the lhs variable was being generalised again. 