### PR TITLE
fix: in orchestration do not input local variables mapping keys to the proof

### DIFF
--- a/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
@@ -131,6 +131,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         accessedOnly,
         privateStateName,
         indicator = {},
+        localMappingKey,
       } = fields;
       const structProperties = !indicator.isStruct ? null : indicator.isAccessed ? indicator.referencingPaths[0]?.getStructDeclaration()?.members.map(m => m.name) : Object.keys(indicator.structProperties);
       return {
@@ -156,6 +157,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         ownerIsSecret: indicator.isOwned
           ? indicator.owner.isSecret || indicator.owner.node?.isSecret
           : null,
+        localMappingKey: localMappingKey,
       };
     }
 

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -150,9 +150,8 @@ export const generateProofBoilerplate = (node: any) => {
     //     isIncluded = true;
     //   }
     // }
-
     const stateVarIdLines =
-      stateNode.isMapping && !(node.parameters.includes(stateNode.stateVarId[1])) && !(node.parameters.includes(stateNode.stateVarId[2])) && !msgSenderParamAndMappingKey && !msgValueParamAndMappingKey && !constantMappingKey
+    !stateNode.localMappingKey && stateNode.isMapping && !(node.parameters.includes(stateNode.stateVarId[1])) && !(node.parameters.includes(stateNode.stateVarId[2])) && !msgSenderParamAndMappingKey && !msgValueParamAndMappingKey && !constantMappingKey
         ? [`\n\t\t\t\t\t\t\t\t${stateName}_stateVarId_key.integer,`]
         : [];  
     // we add any extra params the circuit needs

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign, no-shadow, no-unused-vars, no-continue */
 import NodePath from '../../traverse/NodePath.js';
-import { StateVariableIndicator, FunctionDefinitionIndicator } from '../../traverse/Indicator.js';
+import { StateVariableIndicator, FunctionDefinitionIndicator, LocalVariableIndicator } from '../../traverse/Indicator.js';
 import { VariableBinding } from '../../traverse/Binding.js';
 import MappingKey from '../../traverse/MappingKey.js';
 import cloneDeep from 'lodash.clonedeep';
@@ -737,6 +737,12 @@ const visitor = {
             });
           }
           if (secretModified || accessedOnly) {
+            let localMappingKey = false;
+            if (stateVarIndicator[`keyPath`]){
+              const keyIndicator = path.scope.getReferencedIndicator(stateVarIndicator[`keyPath`].node, true);
+              if (keyIndicator instanceof LocalVariableIndicator && !keyIndicator.isParam) localMappingKey = true;
+            }
+
             newNodes.generateProofNode.privateStates[
               name
             ] = buildPrivateStateNode('GenerateProof', {
@@ -751,6 +757,7 @@ const visitor = {
               increment: isIncremented ? incrementsArray : undefined,
               accessedOnly,
               indicator: stateVarIndicator,
+              localMappingKey: localMappingKey,
             });
           }
 

--- a/test/contracts/MappingtoStruct.zol
+++ b/test/contracts/MappingtoStruct.zol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+contract Assign {
+    secret uint256 private a;
+    address public immutable owner;
+    secret mapping(uint256 => uint256) private b;
+    secret mapping(uint256 => uint256) private c;
+
+    struct myStruct {
+        uint256 prop1;
+        uint256 prop2;
+        uint256 prop3;
+    }
+    secret mapping(uint256 => myStruct) private d;
+
+
+    modifier onlyOwner() {
+        require(
+            msg.sender == owner
+        );
+        _;
+    }
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+
+    function add(secret uint256 value) public onlyOwner {
+        secret uint256 index1 = 0;
+            d[index1].prop1 = value;
+            d[index1].prop2 = value +1;
+            d[index1].prop3 = value +2;
+    }
+
+
+
+
+
+    
+}

--- a/test/contracts/mapping-4.zol
+++ b/test/contracts/mapping-4.zol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+contract Assign {
+
+    secret mapping(uint256 => uint256) private d;
+
+    uint256 public j;
+
+
+    function add(secret uint256 value) public {
+        secret uint256 index1 = 0;
+            d[index1] = value;
+    }
+
+    function add1(secret uint256 value, secret uint256 index1) public {
+            d[index1] = value;
+    }
+
+
+    function add2(secret uint256 value) public {
+            j++;
+            d[j] = value;
+    }
+
+
+
+
+    
+}


### PR DESCRIPTION
When local variables are used as mapping keys, they do not need to be input to the proof. This is because they can be generated from scratch in the circuit. In orchestration the mapping keys were being input whereas in the circuit they were not. 