### PR TITLE
Lyd/interacts secret error

### DIFF
--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1584,7 +1584,7 @@ const visitor = {
       // We don't set interactsWithSecret for state variables because in most cases this is done in addPublicInput anyway. 
       // The cases where this doesn't happen in AddPublicInput are where we don't want to add the statement to the newAST anyway.
       const newNode = buildNode(node.nodeType, {
-        interactsWithSecret: indicator instanceof LocalVariableIndicator && (interactsWithSecret || indicator?.interactsWithSecret),
+        interactsWithSecret: (indicator instanceof LocalVariableIndicator || indicator.isSecret) && (interactsWithSecret || indicator?.interactsWithSecret),
         oldASTId: node.id,
       });
 

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1585,8 +1585,7 @@ const visitor = {
       // We no longer check indicator?.interactsWithSecret because in most cases interactsWithSecret is set to true in addPublicInput anyway. 
       // The cases where this doesn't happen in AddPublicInput are where we don't want to add the statement to the newAST anyway.
       const newNode = buildNode(node.nodeType, {
-        interactsWithSecret: interactsWithSecret,
-        //|| indicator?.interactsWithSecret,
+        interactsWithSecret: interactsWithSecret || indicator?.interactsWithSecret,
         oldASTId: node.id,
       });
 

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1584,7 +1584,7 @@ const visitor = {
       // We don't set interactsWithSecret for state variables because in most cases this is done in addPublicInput anyway. 
       // The cases where this doesn't happen in AddPublicInput are where we don't want to add the statement to the newAST anyway.
       const newNode = buildNode(node.nodeType, {
-        interactsWithSecret: (indicator instanceof LocalVariableIndicator || indicator?.isSecret) && (interactsWithSecret || indicator?.interactsWithSecret),
+        interactsWithSecret: (indicator instanceof LocalVariableIndicator ||  !indicator || indicator?.isSecret) && (interactsWithSecret || indicator?.interactsWithSecret),
         oldASTId: node.id,
       });
 

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -633,7 +633,6 @@ const visitor = {
             }
           }
         });
-        
         // Add publics parametres to sendTransactionNode
         node._newASTPointer.body.postStatements.push(sendPublicTransactionNode);
         node.parameters.parameters.forEach(para => {
@@ -1582,10 +1581,10 @@ const visitor = {
           return;
         }
       }
-      // We no longer check indicator?.interactsWithSecret because in most cases interactsWithSecret is set to true in addPublicInput anyway. 
+      // We don't set interactsWithSecret for state variables because in most cases this is done in addPublicInput anyway. 
       // The cases where this doesn't happen in AddPublicInput are where we don't want to add the statement to the newAST anyway.
       const newNode = buildNode(node.nodeType, {
-        interactsWithSecret: interactsWithSecret || indicator?.interactsWithSecret,
+        interactsWithSecret: indicator instanceof LocalVariableIndicator && (interactsWithSecret || indicator?.interactsWithSecret),
         oldASTId: node.id,
       });
 

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1584,7 +1584,7 @@ const visitor = {
       // We don't set interactsWithSecret for state variables because in most cases this is done in addPublicInput anyway. 
       // The cases where this doesn't happen in AddPublicInput are where we don't want to add the statement to the newAST anyway.
       const newNode = buildNode(node.nodeType, {
-        interactsWithSecret: (indicator instanceof LocalVariableIndicator || indicator.isSecret) && (interactsWithSecret || indicator?.interactsWithSecret),
+        interactsWithSecret: (indicator instanceof LocalVariableIndicator || indicator?.isSecret) && (interactsWithSecret || indicator?.interactsWithSecret),
         oldASTId: node.id,
       });
 

--- a/test/contracts/action-tests/PublicInteractsSecret.zol
+++ b/test/contracts/action-tests/PublicInteractsSecret.zol
@@ -22,4 +22,12 @@ contract Assign {
      j++;
   }
 
+  function add1(secret uint256 value, uint256 value_pub) public {
+    uint256 k =0;
+    k++;
+    known a += value + k + value_pub;
+    k++;
+    known c += value + k + value_pub;
+  }
+
 }

--- a/test/contracts/action-tests/PublicInteractsSecret.zol
+++ b/test/contracts/action-tests/PublicInteractsSecret.zol
@@ -18,8 +18,8 @@ contract Assign {
     index++;
     index++;
     known c += value + j+index;
-     index++;
-     j++;
+    index++;
+    j++;
   }
 
   function add1(secret uint256 value, uint256 value_pub) public {

--- a/test/test.js
+++ b/test/test.js
@@ -35,9 +35,9 @@ describe("AST testing", function () {
     it("zappifies each contract", function () {
       this.timeout(100000);
       files.forEach((file) => {
+        options.inputFilePath = file;
         options.inputFileName = path.parse(options.inputFilePath).name;
         logger.info('zappifying', options.inputFileName);
-        options.inputFilePath = file;
         options.modifyAST = 'n';
         // commander converts 'zapp-name' to 'zappName'
         options.zappName = options.inputFileName;


### PR DESCRIPTION
Fixes an error where statements for public local variables that later interact with secret variables were not appearing in orchestration files. This is because interactsWithSecret was not being set in the relevant node in the AST. 

Also fixes an error in the testing where the logging info was coming in the wrong order.