### PR TITLE
chore: improve error handling for unsupported public contracts

### DIFF
--- a/test/error-checks/Fully-public-contract.zol
+++ b/test/error-checks/Fully-public-contract.zol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+contract Receipt {
+
+    mapping (address => Rct) private total;
+    secret uint256 a;
+
+    struct Rct {
+        uint256 amount;
+        uint256 tax;
+    }
+
+    function add(Rct memory myrct, address user) public {
+        total[user].amount += myrct.amount;
+        total[user].tax += myrct.tax;
+    }
+
+}


### PR DESCRIPTION

This PR adds a validation step to ensure the transpiler only processes Zolidity contracts that use secret variables. If all functions do not modify the secret state after AST traversal of the contract, an error is now thrown with a clear message.

Previously, fully public contracts would cause an exception without any informative error, making it harder to diagnose the issue.

Fixes #336.

## Testing this PR
At the root of the Starlight repository, assuming everything is set up correctly:
```
$ tsc # compile Starlight
$ zappify -i test/error-checks/Fully-public-contract.zol
Error: The contract is fully public and does not use secret variables, making it incompatible with the transpiler. Ensure your contract manipulates secret variables to generate a valid ZApp.
    at Object.exit (file:///Users/Julien.Coolen/starlight/built/transformers/visitors/ownership/errorChecksVisitor.js:170:23)
    at traverse (file:///Users/Julien.Coolen/starlight/built/traverse/traverse.js:82:17)
    at NodePath.traverse (file:///Users/Julien.Coolen/starlight/built/traverse/NodePath.js:111:9)
    at traverse (file:///Users/Julien.Coolen/starlight/built/traverse/traverse.js:65:29)
    at NodePath.traverse (file:///Users/Julien.Coolen/starlight/built/traverse/NodePath.js:111:9)
    at transformation1 (file:///Users/Julien.Coolen/starlight/built/transformers/ownership.js:19:9)
    at ownership (file:///Users/Julien.Coolen/starlight/built/transformers/ownership.js:27:28)
    at zappify (file:///Users/Julien.Coolen/starlight/built/index.js:18:12)
    at file:///Users/Julien.Coolen/starlight/bin/index.mjs:108:1
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
```