### PR TITLE
Support modifying function parameters

### DIFF
--- a/test/contracts/action-tests/PublicInteractsSecret.zol
+++ b/test/contracts/action-tests/PublicInteractsSecret.zol
@@ -12,8 +12,10 @@ contract Assign {
   uint256 public index;
   uint256 public j;
 
-  function add(secret uint256 value) public {
+  function add(secret uint256 value, uint256 value_pub) public {
     index++;
+    value_pub = value_pub + 1;
+    value = value + 1 + value_pub;
     known a += value + index;
     index++;
     index++;


### PR DESCRIPTION
This change allows to mutate function parameters which were previously declared as const in the orchestration contract.

To enable mutation of function arguments within the generated code, we remove the const keyword from their local copies. Additionally, we pass the original (unmodified) values of these arguments—using a `*_init` naming convention — to the circuit inputs and to the proof verification in the shielded contract, ensuring the proof and verification logic receives the correct, unaltered inputs.

Fixes #387.

## Testing

```
$ tsc
$ zappify -i test/contracts/action-tests/PublicInteractsSecret.zol
$ cd zapps/PublicInteractsSecret
$ sh bin/setup
$ sh bin/startup
$ curl -X POST "http://localhost:3000/add" -H "Content-Type: application/json"  -d '{"value": 2, "value_pub": 11110}'
```