### PR TITLE
feat: sequencing warning for secret assignments based on public vars

### DIFF
--- a/src/transformers/visitors/checks/accessedVisitor.ts
+++ b/src/transformers/visitors/checks/accessedVisitor.ts
@@ -74,6 +74,7 @@ export default {
           logger.warn(
             `Non-secret parameter '${node.name}' used when assigning to a secret variable '${lhsBinding.name}'. Blockchain observers might be able to infer the value of '${lhsBinding.name}' from this. I.e. although you've labelled '${lhsBinding.name}' as 'secret', it might not be secret.`,
           );
+          logger.warn(`The secret variable '${lhsBinding.name}' is assigned a value derived from the non-secret parameter '${node.name}'. If '${node.name}' is modified in a concurrently issued transaction that is ordered before this one, it could invalidate the cryptographic proof backing the secret state change. This may result in the transaction failing, leading to wasted gas and proving effort.`);
           backtrace.getSourceCode(node.src);
         }
         // if its non-secret, no accessing occurs, we exit


### PR DESCRIPTION
This PR adds a new static analysis warning to Starlight that detects potential sequencing issues when a secret variable is assigned a value derived from a public variable.

In contracts where secret variables depend on public parameters, there's a risk of transaction failure due to reordering. If a public variable is updated in a separate transaction that gets mined before the one updating the secret variable, the associated zero-knowledge proof may become invalid. This can cause the transaction to revert, leading to wasted gas and proving computation.

Fixes https://github.com/EYBlockchain/starlight/issues/386.