### PR TITLE
fix: fix getPastEvents by adding From and To block number

### DIFF
--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -529,7 +529,10 @@ export async function joinCommitments(
 
   const sendTxn = await web3.eth.sendSignedTransaction(signed.rawTransaction);
 
-  let tx = await instance.getPastEvents('allEvents');
+  let tx = await instance.getPastEvents('allEvents', {
+    fromBlock: sendTxn?.blockNumber || 0,
+    toBlock: sendTxn?.blockNumber || 'latest',
+  });
 
   tx = tx[0];
 
@@ -695,7 +698,10 @@ export async function splitCommitments(
 
   const sendTxn = await web3.eth.sendSignedTransaction(signed.rawTransaction);
 
-  let tx = await instance.getPastEvents('allEvents');
+  let tx = await instance.getPastEvents('allEvents', {
+    fromBlock: sendTxn?.blockNumber || 0,
+    toBlock: sendTxn?.blockNumber || 'latest',
+  });
 
   tx = tx[0];
 

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -955,20 +955,20 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
             \n 	const key = config.web3.key;
             \n 	const signed = await web3.eth.accounts.signTransaction(txParams, key);
             \n 	const sendTxn = await web3.eth.sendSignedTransaction(signed.rawTransaction);
-            \n  let tx = await instance.getPastEvents("NewLeaves");
+            \n  let tx = await instance.getPastEvents("NewLeaves", {fromBlock: sendTxn?.blockNumber || 0, toBlock: sendTxn?.blockNumber || 'latest'});
             \n tx = tx[0];\n
             \n if (!tx) {
               throw new Error( 'Tx failed - the commitment was not accepted on-chain, or the contract is not deployed.');
             } \n
             let encEvent = '';
             \n try {
-            \n  encEvent = await instance.getPastEvents("EncryptedData");
+            \n  encEvent = await instance.getPastEvents("EncryptedData", {fromBlock: sendTxn?.blockNumber || 0, toBlock: sendTxn?.blockNumber || 'latest'});
             \n } catch (err) {
             \n  console.log('No encrypted event');
             \n}
             \nlet encBackupEvent = '';
             \n try {
-            \n  encBackupEvent = await instance.getPastEvents("EncryptedBackupData");
+            \n  encBackupEvent = await instance.getPastEvents("EncryptedBackupData", {fromBlock: sendTxn?.blockNumber || 0, toBlock: sendTxn?.blockNumber || 'latest'});
             \n } catch (err) {
             \n  console.log('No encrypted backup event');
             \n}`,


### PR DESCRIPTION
1. In `getPastEvents` call, add block filter and use blockNumber property only if it exists in the transaction response