### PR TITLE
delete key database during an npm start

### DIFF
--- a/src/boilerplate/common/bin/startup
+++ b/src/boilerplate/common/bin/startup
@@ -12,6 +12,8 @@ while docker compose -f docker-compose.zapp.yml ps | grep -q 'Up'; do
   sleep 1
 done
 
+rm -f ./orchestration/common/db/key.json
+
 docker compose -f docker-compose.zapp.yml up -d ganache
 docker compose -f docker-compose.zapp.yml up -d zokrates
 


### PR DESCRIPTION
The key.json file in orchestration/common/db stores the user's secret and public keys. If this file does not exist then it will generate new keys create the file, and then also in some cases register the key on-chain. The problem is that if the key.json file exists but the contract has been redeployed, the old key will be used but this one will not longer be registered on chain causing an error. To fix this this PR deletes this file during ./bin/startup. 