### PR TITLE
fix: build timber-mongo and zapp-mongo Docker images in startup script

### DIFF
--- a/src/boilerplate/common/bin/startup
+++ b/src/boilerplate/common/bin/startup
@@ -50,6 +50,9 @@ if [ "$exit_code" -eq 1 ]; then
   exit 1
 fi
 
+docker compose -f docker-compose.zapp.yml build timber-mongo
+
+docker compose -f docker-compose.zapp.yml build zapp-mongo
 
 docker compose -f docker-compose.zapp.yml up -d timber
 


### PR DESCRIPTION
Compose never built (or tagged) the timber-mongo and zapp-mongo images before trying to start it.