### PR TITLE
Use Zokrates' worker Docker image from eyblockchain registry

### DIFF
--- a/src/boilerplate/common/boilerplate-docker-compose.yml
+++ b/src/boilerplate/common/boilerplate-docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - zapp_network
 
   zokrates:
-    image: ghcr.io/jtcoolen/zokrates-worker-api:latest
+    image: ghcr.io/eyblockchain/zokrates-worker-updated:latest
     # the following image is for arm64 architecture. Uncomment the following lines and comment the above line if you are using ARM
     # image: ghcr.io/eyblockchain/zokrates-worker-starlight:v0.2
     # platform: linux/arm64/v8

--- a/src/boilerplate/common/boilerplate-docker-compose.zapp-double.yml
+++ b/src/boilerplate/common/boilerplate-docker-compose.zapp-double.yml
@@ -56,7 +56,7 @@ services:
       - zapp_network    
 
   zokrates:
-    image: ghcr.io/jtcoolen/zokrates-worker-api:latest
+    image: ghcr.io/eyblockchain/zokrates-worker-updated:latest
     # the following image is for arm64 architecture. Uncomment the following lines and comment the above line if you are using ARM
     # image: ghcr.io/eyblockchain/zokrates-worker-starlight:v0.2
     # platform: linux/arm64/v8
@@ -71,7 +71,7 @@ services:
       - zapp_network
 
   zokrates2:
-    image: ghcr.io/jtcoolen/zokrates-worker-api:latest
+    image: ghcr.io/eyblockchain/zokrates-worker-updated:latest
     # the following image is for arm64 architecture. Uncomment the following lines and comment the above line if you are using ARM
     # image: ghcr.io/eyblockchain/zokrates-worker-starlight:v0.2
     # platform: linux/arm64/v8

--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,6 @@ for zokelement in "${zokarray[@]}"
 do
     zokelement="${zokelement:1}"
     echo “$(tput setaf 7) $zokelement compiling”
-    docker run -v $PWD:/app/code --name testcircuits -ti ghcr.io/jtcoolen/zokrates-worker-api:latest ./zokrates compile -i code$zokelement || echo “$(tput setaf 1) $zokelement failed”
+    docker run -v $PWD:/app/code --name testcircuits -ti ghcr.io/eyblockchain/zokrates-worker-updated:latest ./zokrates compile -i code$zokelement || echo “$(tput setaf 1) $zokelement failed”
     docker rm testcircuits
 done


### PR DESCRIPTION
See the corresponding PR https://github.com/EYBlockchain/zokrates-worker/pull/42 in the Zokrates worker repository. Pushed the Zokrates worker image to the EY Blockchain docker registry.