### PR TITLE
Fix counterparty bug in Swap contract 

### DIFF
--- a/apitest.js
+++ b/apitest.js
@@ -336,7 +336,7 @@ const apiRequests_Swap = [
     endpoint: '/completeSwap',
     data: {
       sharedAddress: '', // to be filled in preHook
-      counterParty: counterParty,
+      counterParty: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
       amountSent: 0,
       tokenIdSent: 2,
       tokenIdRecieved: 1,
@@ -896,14 +896,16 @@ describe('Swap Zapp', () => {
       swapAmountSent: '30',
       swapAmountRecieved: '0',
       swapTokenSent: '1',
-      swapTokenRecieved: '2'
+      swapTokenRecieved: '2',
+      swapInitiator: '1390849295786071768276380950238675083608645509734'
     });
     expect(res.Swap[6].body.commitments[13].name).to.equal("swapProposals");
     expect(res.Swap[6].body.commitments[13].preimage.value).to.deep.equal({
       swapAmountSent: '0',
       swapAmountRecieved: '0',
       swapTokenSent: '1',
-      swapTokenRecieved: '2'
+      swapTokenRecieved: '2',
+      swapInitiator: '1390849295786071768276380950238675083608645509734'
     });
   });
 });

--- a/apitest.js
+++ b/apitest.js
@@ -845,13 +845,13 @@ describe('Swap Zapp', () => {
     expect(parseInt(res.Swap[0].body.tx.returnValues.minLeafIndex)).to.equal(0); // deposit 1
     expect(parseInt(res.Swap[1].body.tx.returnValues.minLeafIndex)).to.equal(2); // deposit 2
     expect(parseInt(res.Swap[3].body.tx.returnValues.minLeafIndex)).to.equal(4); // startSwap
-    expect(parseInt(res.Swap[5].body.tx.returnValues.minLeafIndex)).to.equal(8); // completeSwap
+    expect(parseInt(res.Swap[5].body.tx.returnValues.minLeafIndex)).to.equal(7); // completeSwap
   });
 
   it('Check number of commitments', async () => {
     expect(res.Swap[2].body.commitments.length).to.equal(4);
-    expect(res.Swap[4].body.commitments.length).to.equal(8);
-    expect(res.Swap[6].body.commitments.length).to.equal(14);
+    expect(res.Swap[4].body.commitments.length).to.equal(7);
+    expect(res.Swap[6].body.commitments.length).to.equal(12);
   });
 
   it('Check nullified commitments', async () => {
@@ -867,7 +867,6 @@ describe('Swap Zapp', () => {
     expect(res.Swap[4].body.commitments[4].isNullified).to.equal(false);
     expect(res.Swap[4].body.commitments[5].isNullified).to.equal(false);
     expect(res.Swap[4].body.commitments[6].isNullified).to.equal(false);
-    expect(res.Swap[4].body.commitments[7].isNullified).to.equal(false);
 
     expect(res.Swap[6].body.commitments[0].isNullified).to.equal(true);
     expect(res.Swap[6].body.commitments[1].isNullified).to.equal(true);
@@ -876,13 +875,11 @@ describe('Swap Zapp', () => {
     expect(res.Swap[6].body.commitments[4].isNullified).to.equal(false);
     expect(res.Swap[6].body.commitments[5].isNullified).to.equal(true);
     expect(res.Swap[6].body.commitments[6].isNullified).to.equal(true);
-    expect(res.Swap[6].body.commitments[7].isNullified).to.equal(true);
+    expect(res.Swap[6].body.commitments[7].isNullified).to.equal(false);
     expect(res.Swap[6].body.commitments[8].isNullified).to.equal(false);
     expect(res.Swap[6].body.commitments[9].isNullified).to.equal(false);
     expect(res.Swap[6].body.commitments[10].isNullified).to.equal(false);
     expect(res.Swap[6].body.commitments[11].isNullified).to.equal(false);
-    expect(res.Swap[6].body.commitments[12].isNullified).to.equal(false);
-    expect(res.Swap[6].body.commitments[13].isNullified).to.equal(false);
   });
 
   it('Check value of final commitment', async () => {
@@ -890,22 +887,23 @@ describe('Swap Zapp', () => {
     expect(parseInt(res.Swap[6].body.commitments[2].preimage.value)).to.equal(100); // deposit 2
     expect(res.Swap[6].body.commitments[4].name).to.equal("balances");
     expect(parseInt(res.Swap[6].body.commitments[4].preimage.value)).to.equal(170); // startSwap balance: 200-30
-    expect(parseInt(res.Swap[6].body.commitments[6].preimage.value)).to.equal(1); // pendingStatus
-    expect(res.Swap[6].body.commitments[7].name).to.equal("swapProposals");
-    expect(res.Swap[6].body.commitments[7].preimage.value).to.deep.equal({
+    expect(res.Swap[6].body.commitments[6].name).to.equal("swapProposals");
+    expect(res.Swap[6].body.commitments[6].preimage.value).to.deep.equal({
       swapAmountSent: '30',
       swapAmountRecieved: '0',
       swapTokenSent: '1',
       swapTokenRecieved: '2',
-      swapInitiator: '1390849295786071768276380950238675083608645509734'
+      swapInitiator: '1390849295786071768276380950238675083608645509734',
+      pendingStatus: '1'
     });
-    expect(res.Swap[6].body.commitments[13].name).to.equal("swapProposals");
-    expect(res.Swap[6].body.commitments[13].preimage.value).to.deep.equal({
+    expect(res.Swap[6].body.commitments[11].name).to.equal("swapProposals");
+    expect(res.Swap[6].body.commitments[11].preimage.value).to.deep.equal({
       swapAmountSent: '0',
       swapAmountRecieved: '0',
       swapTokenSent: '1',
       swapTokenRecieved: '2',
-      swapInitiator: '1390849295786071768276380950238675083608645509734'
+      swapInitiator: '1390849295786071768276380950238675083608645509734',
+      pendingStatus: '0'
     });
   });
 });

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -1123,10 +1123,13 @@ const visitor = {
                   // we need to splice this local var dec between two initialisePreimage nodes
                   // so here we find the place to split
                   if (
+                    ((Array.isArray(stateNode.stateVarId) &&
                     stateNode.stateVarId[0] === varDecComesAfterSVID[0] &&
-                    stateNode.stateVarId[1] === varDecComesAfterSVID[1] &&
+                    stateNode.stateVarId[1] === varDecComesAfterSVID[1]) ||
+                    (!Array.isArray(stateNode.stateVarId) && stateNode.stateVarId === varDecComesAfterSVID[0])) &&
                     sortPreimage === 1
-                  ) {
+                  )
+                  {
                     correctlyComesAfter = true;
                   }
 

--- a/test/contracts/user-friendly-tests/Swap.zol
+++ b/test/contracts/user-friendly-tests/Swap.zol
@@ -11,7 +11,7 @@ contract Swap {
         uint256 swapAmountRecieved;
         uint256 swapTokenSent;
         uint256 swapTokenRecieved;
-        
+        address swapInitiator;
     }
     sharedSecret uint256 pendingStatus;
     
@@ -32,6 +32,7 @@ contract Swap {
             swapProposals[sharedAddress].swapTokenSent = tokenIdSent;
             swapProposals[sharedAddress].swapAmountRecieved += amountRecieved;
             swapProposals[sharedAddress].swapTokenRecieved = tokenIdRecieved;
+            swapProposals[sharedAddress].swapInitiator = msg.sender;
             pendingStatus = 1;
        
     }
@@ -41,11 +42,11 @@ contract Swap {
            require(swapProposals[sharedAddress].swapAmountRecieved == amountSent && swapProposals[sharedAddress].swapTokenRecieved == tokenIdSent);
            require(swapProposals[sharedAddress].swapAmountSent == amountRecieved && swapProposals[sharedAddress].swapTokenSent == tokenIdRecieved);
            require(pendingStatus == 1);
+           require(counterParty == swapProposals[sharedAddress].swapInitiator);
             swapProposals[sharedAddress].swapAmountSent -= amountRecieved;
             swapProposals[sharedAddress].swapAmountRecieved -= amountSent;
             balances[msg.sender] +=  amountRecieved - amountSent; 
             unknown balances[counterParty] += amountSent; 
-
             tokenOwners[tokenIdSent] = counterParty;
             
             tokenOwners[tokenIdRecieved] = msg.sender;

--- a/test/contracts/user-friendly-tests/Swap.zol
+++ b/test/contracts/user-friendly-tests/Swap.zol
@@ -12,8 +12,8 @@ contract Swap {
         uint256 swapTokenSent;
         uint256 swapTokenRecieved;
         address swapInitiator;
+        uint256 pendingStatus;
     }
-    sharedSecret uint256 pendingStatus;
     
     sharedSecret mapping(address => swapStruct) swapProposals;  
 
@@ -25,7 +25,7 @@ contract Swap {
 
     function startSwap(secret address sharedAddress,  secret uint256 amountSent, secret uint256 tokenIdSent, secret uint256 amountRecieved, secret uint256 tokenIdRecieved) public {
         
-           require(pendingStatus == 0);
+           require(swapProposals[sharedAddress].pendingStatus == 0);
             swapProposals[sharedAddress].swapAmountSent += amountSent;
             balances[msg.sender] -= amountSent; 
             tokenOwners[tokenIdSent] = sharedAddress;
@@ -33,7 +33,7 @@ contract Swap {
             swapProposals[sharedAddress].swapAmountRecieved += amountRecieved;
             swapProposals[sharedAddress].swapTokenRecieved = tokenIdRecieved;
             swapProposals[sharedAddress].swapInitiator = msg.sender;
-            pendingStatus = 1;
+            swapProposals[sharedAddress].pendingStatus = 1;
        
     }
 
@@ -41,7 +41,7 @@ contract Swap {
            
            require(swapProposals[sharedAddress].swapAmountRecieved == amountSent && swapProposals[sharedAddress].swapTokenRecieved == tokenIdSent);
            require(swapProposals[sharedAddress].swapAmountSent == amountRecieved && swapProposals[sharedAddress].swapTokenSent == tokenIdRecieved);
-           require(pendingStatus == 1);
+           require(swapProposals[sharedAddress].pendingStatus == 1);
            require(counterParty == swapProposals[sharedAddress].swapInitiator);
             swapProposals[sharedAddress].swapAmountSent -= amountRecieved;
             swapProposals[sharedAddress].swapAmountRecieved -= amountSent;
@@ -50,21 +50,21 @@ contract Swap {
             tokenOwners[tokenIdSent] = counterParty;
             
             tokenOwners[tokenIdRecieved] = msg.sender;
-            pendingStatus = 0;
+            swapProposals[sharedAddress].pendingStatus = 0;
          
     }
 
     function quitSwap(secret address sharedAddress,  secret uint256 amountSent, secret uint256 tokenIdSent) public {
            
            require(swapProposals[sharedAddress].swapAmountSent == amountSent && swapProposals[sharedAddress].swapTokenSent == tokenIdSent);
-           require(pendingStatus == 1);
+           require(swapProposals[sharedAddress].pendingStatus == 1);
             swapProposals[sharedAddress].swapAmountSent -= amountSent;
             balances[msg.sender] += amountSent; 
             tokenOwners[tokenIdSent] = msg.sender;
             swapProposals[sharedAddress].swapTokenSent = 0;
             swapProposals[sharedAddress].swapTokenRecieved = 0;
             swapProposals[sharedAddress].swapAmountRecieved = 0;
-            pendingStatus = 0;
+            swapProposals[sharedAddress].pendingStatus = 0;
          
     }
 }


### PR DESCRIPTION
This PR fixes a security issue in the swap contract. The entity who completes the swap can choose whichever address they like for the counterparty, and is not restricted to using the address of the entity that started the swap. This means they can use their own address and so keep both the tokens sent and the tokens received. 
Also fixes an unrelated bug, where it is assumed that the state variable id is for a mapping, but actually it could be for a non-mapping.  