### PR TITLE
Escrow contract changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ This code is not owned by EY and EY provides no warranty and disclaims any and a
 
 **In the same way that Solidity does not protect against contract vulnerabilities, Starlight cannot protect against zApp vulnerabilities once they are written into the code. This compiler assumes knowledge of smart contract security.**
 
+**Note on integer limits:**
+Starlight compiles your Solidity contract into a zApp written in JavaScript. Unlike Solidity's `uint256` (which supports integers up to 2^256-1), JavaScript's standard `Number` type can only safely represent integers up to 9,007,199,254,740,991 (2^53 – 1), known as `Number.MAX_SAFE_INTEGER`.  This means that values above 2^53–1 are not fully supported in the JavaScript output, and large values will lose precision or behave unexpectedly. When designing your contracts, ensure that all values remain within the safe integer range for JavaScript.
+
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/apitest.js
+++ b/apitest.js
@@ -501,8 +501,7 @@ const apiRequests_Swap = [
       sharedAddress: '', // to be filled in preHook
       amountSent: 30,
       tokenIdSent: 1,
-      tokenIdRecieved: 2,
-      amountRecieved: 0
+      tokenIdRecieved: 2
     }
   },
   { method: 'get', endpoint: '/getAllCommitments' },
@@ -512,7 +511,6 @@ const apiRequests_Swap = [
     data: {
       sharedAddress: '', // to be filled in preHook
       counterParty: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-      amountSent: 0,
       tokenIdSent: 2,
       tokenIdRecieved: 1,
       amountRecieved: 30
@@ -537,8 +535,12 @@ const preHook = async (requests) => {
   }
 };
 
-res.Swap = await callZAppAPIs('Swap', apiRequests_Swap, 'Swap Zapp failed', preHook);
-
+res.Swap = await callZAppAPIs(
+  'Swap',
+  apiRequests_Swap,
+  'Swap Zapp failed',
+  preHook,
+);
 
 const userFriendlyTestsPath = 'test/contracts/user-friendly-tests';
 const userFriendlyTests = await getUserFriendlyTestNames(userFriendlyTestsPath);
@@ -1166,7 +1168,6 @@ describe('Swap Zapp', () => {
     expect(res.Swap[6].body.commitments[6].name).to.equal("swapProposals");
     expect(res.Swap[6].body.commitments[6].preimage.value).to.deep.equal({
       swapAmountSent: '30',
-      swapAmountRecieved: '0',
       swapTokenSent: '1',
       swapTokenRecieved: '2',
       swapInitiator: '1390849295786071768276380950238675083608645509734',
@@ -1175,7 +1176,6 @@ describe('Swap Zapp', () => {
     expect(res.Swap[6].body.commitments[11].name).to.equal("swapProposals");
     expect(res.Swap[6].body.commitments[11].preimage.value).to.deep.equal({
       swapAmountSent: '0',
-      swapAmountRecieved: '0',
       swapTokenSent: '1',
       swapTokenRecieved: '2',
       swapInitiator: '1390849295786071768276380950238675083608645509734',

--- a/apitest.js
+++ b/apitest.js
@@ -1150,7 +1150,7 @@ describe('Swap Zapp', () => {
     expect(res.Swap[6].body.commitments[1].isNullified).to.equal(true);
     expect(res.Swap[6].body.commitments[2].isNullified).to.equal(true);
     expect(res.Swap[6].body.commitments[3].isNullified).to.equal(true);
-    expect(res.Swap[6].body.commitments[4].isNullified).to.equal(false);
+    expect(res.Swap[6].body.commitments[4].isNullified).to.equal(true);
     expect(res.Swap[6].body.commitments[5].isNullified).to.equal(true);
     expect(res.Swap[6].body.commitments[6].isNullified).to.equal(true);
     expect(res.Swap[6].body.commitments[7].isNullified).to.equal(false);
@@ -1172,8 +1172,8 @@ describe('Swap Zapp', () => {
       swapInitiator: '1390849295786071768276380950238675083608645509734',
       pendingStatus: '1'
     });
-    expect(res.Swap[6].body.commitments[11].name).to.equal("swapProposals");
-    expect(res.Swap[6].body.commitments[11].preimage.value).to.deep.equal({
+    expect(res.Swap[6].body.commitments[10].name).to.equal("swapProposals");
+    expect(res.Swap[6].body.commitments[10].preimage.value).to.deep.equal({
       swapAmountSent: '0',
       swapTokenSent: '1',
       swapTokenRecieved: '2',

--- a/apitest.js
+++ b/apitest.js
@@ -202,8 +202,11 @@ const apiRequests_Encrypt = [
 
 res.Encrypt = await callZAppAPIs('Encrypt', apiRequests_Encrypt, 'Encrypt Zapp failed');
 
-// In order to test Escrow we first need to mint ERC tokens. 
-const depositFilePath = path.join(__dirname, 'temp-zapps/Escrow/orchestration/deposit.mjs');
+// In order to test Escrow we first need to mint ERC tokens
+const depositFilePath = path.join(
+  __dirname,
+  'temp-zapps/Escrow/orchestration/deposit.mjs',
+);
 let depositContent = fs.readFileSync(depositFilePath, 'utf8');
 position = depositContent.indexOf(keyword);
 if (position !== -1) {
@@ -215,27 +218,84 @@ if (position !== -1) {
 }
 fs.writeFileSync(depositFilePath, depositContent, 'utf8');
 
-console.log('deposit.mjs in Escrow modified successfully to mint ERC tokens. Proceeding with the test...');
+console.log(
+  'deposit.mjs in Escrow modified successfully to mint ERC tokens. Proceeding with the test...',
+);
 
 const apiRequests_Escrow = [
   { method: 'post', endpoint: '/deposit', data: { amount: 25 } },
   { method: 'post', endpoint: '/deposit', data: { amount: 19 } },
-  { method: 'post', endpoint: '/transfer', data: { recipient: 235, amount: 13 } },
+  {
+    method: 'post',
+    endpoint: '/transfer',
+    data: { recipient: 235, amount: 13 },
+  },
   { method: 'post', endpoint: '/withdraw', data: { amount: 3 } },
-  { method: 'post', endpoint: '/transferFrom', data: {sender: '1390849295786071768276380950238675083608645509734', recipient: 235, amount: 1 } },
+  {
+    method: 'post',
+    endpoint: '/approve',
+    data: {
+      approvedAddress: '1390849295786071768276380950238675083608645509734',
+    },
+  },
+  {
+    method: 'post',
+    endpoint: '/transferFrom',
+    data: {
+      sender: '1390849295786071768276380950238675083608645509734',
+      recipient: 235,
+      amount: 1,
+    },
+  },
   { method: 'get', endpoint: '/getAllCommitments' },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'balances', mappingKey: '1390849295786071768276380950238675083608645509734'} },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'balances', mappingKey: '235'} },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'tokens' } },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: {
+      name: 'balances',
+      mappingKey: '1390849295786071768276380950238675083608645509734',
+    },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'balances', mappingKey: '235' },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokens' },
+  },
   { method: 'get', endpoint: '/backupDataRetriever' },
   { method: 'get', endpoint: '/getAllCommitments' },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'balances', mappingKey: '1390849295786071768276380950238675083608645509734'} },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'balances', mappingKey: '235'} },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'tokens' } },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: {
+      name: 'balances',
+      mappingKey: '1390849295786071768276380950238675083608645509734',
+    },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'balances', mappingKey: '235' },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokens' },
+  },
   { method: 'post', endpoint: '/withdraw', data: { amount: 7 } },
 ];
 
-res.Escrow = await callZAppAPIs('Escrow', apiRequests_Escrow, 'Escrow Zapp failed', undefined, "\"NA\"");
+res.Escrow = await callZAppAPIs(
+  'Escrow',
+  apiRequests_Escrow,
+  'Escrow Zapp failed',
+  undefined,
+  '"NA"',
+);
 
 const apiRequests_forloop = [
   { method: 'post', endpoint: '/add', data: { j: 8 } },
@@ -282,7 +342,7 @@ const apiRequests_MappingtoStruct = [
 res.MappingtoStruct = await callZAppAPIs('MappingtoStruct', apiRequests_MappingtoStruct, 'MappingtoStruct Zapp failed');
 
 // In order to test NFT_Escrow we first need to mint a token. 
-let NFTmintingText = `const erc721 = await getContractInstance("ERC721");
+const NFTmintingText = `const erc721 = await getContractInstance("ERC721");
 let mintBalance = await erc721.methods
 		.balanceOf(config.web3.options.defaultAccount, this.contractAddr)
 		.call({ from: config.web3.options.defaultAccount });
@@ -300,8 +360,17 @@ if (mintBalance === BigInt(0)) {
   await erc721.methods
       .approve(this.contractAddr, 87654321)
       .send({ from: config.web3.options.defaultAccount });
+  await erc721.methods
+      .mint(config.web3.options.defaultAccount, 23456789)
+      .send({ from: config.web3.options.defaultAccount });
+  await erc721.methods
+      .approve(this.contractAddr, 23456789)
+      .send({ from: config.web3.options.defaultAccount });
 }`;
-const depositNFTFilePath = path.join(__dirname, 'temp-zapps/NFT_Escrow/orchestration/deposit.mjs');
+const depositNFTFilePath = path.join(
+  __dirname,
+  'temp-zapps/NFT_Escrow/orchestration/deposit.mjs',
+);
 let depositNFTContent = fs.readFileSync(depositNFTFilePath, 'utf8');
 position = depositNFTContent.indexOf(keyword);
 if (position !== -1) {
@@ -313,23 +382,78 @@ if (position !== -1) {
 }
 fs.writeFileSync(depositNFTFilePath, depositNFTContent, 'utf8');
 
-console.log('deposit.mjs in NFT_Escrow modified successfully to mint an ERC721 token. Proceeding with the test...');
+console.log(
+  'deposit.mjs in NFT_Escrow modified successfully to mint an ERC721 token. Proceeding with the test...',
+);
 
 const apiRequests_NFT_Escrow = [
   { method: 'post', endpoint: '/deposit', data: { tokenId: 12345678 } },
   { method: 'post', endpoint: '/deposit', data: { tokenId: 87654321 } },
-  { method: 'post', endpoint: '/transfer', data: { recipient: 235, tokenId: 12345678 } },
+  { method: 'post', endpoint: '/deposit', data: { tokenId: 23456789 } },
+  {
+    method: 'post',
+    endpoint: '/transfer',
+    data: { recipient: 235, tokenId: 12345678 },
+  },
   { method: 'post', endpoint: '/withdraw', data: { tokenId: 87654321 } },
+  {
+    method: 'post',
+    endpoint: '/approve',
+    data: {
+      approvedAddress: '1390849295786071768276380950238675083608645509734',
+    },
+  },
+  {
+    method: 'post',
+    endpoint: '/transferFrom',
+    data: {
+      sender: '1390849295786071768276380950238675083608645509734',
+      recipient: 578,
+      amount: 23456789,
+    },
+  },
   { method: 'get', endpoint: '/getAllCommitments' },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'tokenOwners', mappingKey: '12345678'} },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'tokenOwners', mappingKey: '87654321'} },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokenOwners', mappingKey: '12345678' },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokenOwners', mappingKey: '87654321' },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokenOwners', mappingKey: '23456789' },
+  },
   { method: 'get', endpoint: '/backupDataRetriever' },
   { method: 'get', endpoint: '/getAllCommitments' },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'tokenOwners', mappingKey: '12345678'} },
-  { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'tokenOwners', mappingKey: '87654321'} },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokenOwners', mappingKey: '12345678' },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokenOwners', mappingKey: '87654321' },
+  },
+  {
+    method: 'get',
+    endpoint: '/getCommitmentsByVariableName',
+    data: { name: 'tokenOwners', mappingKey: '23456789' },
+  }
 ];
 
-res.NFT_Escrow = await callZAppAPIs('NFT_Escrow', apiRequests_NFT_Escrow, 'NFT_Escrow Zapp failed', undefined, "\"NA\"");
+res.NFT_Escrow = await callZAppAPIs(
+  'NFT_Escrow',
+  apiRequests_NFT_Escrow,
+  'NFT_Escrow Zapp failed',
+  undefined,
+  '"NA"',
+);
 
 const apiRequests_Return = [
   { method: 'post', endpoint: '/add', data: { value: 21 } },
@@ -667,55 +791,79 @@ describe('Escrow Zapp', () => {
     expect(res.Escrow[2].body.tx.event).to.equal('NewLeaves');
     expect(res.Escrow[3].body.tx.event).to.equal('NewLeaves');
     expect(res.Escrow[4].body.tx.event).to.equal('NewLeaves');
+    expect(res.Escrow[5].body.tx.event).to.equal('NewLeaves');
   });
   it('MinLeaf Index check', async () => {
-    expect(parseInt(res.Escrow[0].body.tx.returnValues.minLeafIndex)).to.equal(0);
-    expect(parseInt(res.Escrow[1].body.tx.returnValues.minLeafIndex)).to.equal(2);
-    expect(parseInt(res.Escrow[2].body.tx.returnValues.minLeafIndex)).to.equal(4);
-    expect(parseInt(res.Escrow[3].body.tx.returnValues.minLeafIndex)).to.equal(8);
-    expect(parseInt(res.Escrow[4].body.tx.returnValues.minLeafIndex)).to.equal(11);
+    expect(
+      parseInt(res.Escrow[0].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(0);
+    expect(
+      parseInt(res.Escrow[1].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(2);
+    expect(
+      parseInt(res.Escrow[2].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(4);
+    expect(
+      parseInt(res.Escrow[3].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(8);
+    expect(
+      parseInt(res.Escrow[4].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(11);
+    expect(
+      parseInt(res.Escrow[5].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(12);
   });
   it('Check number of commitments', async () => {
-    expect(res.Escrow[5].body.commitments.length).to.equal(13);
+    expect(res.Escrow[6].body.commitments.length).to.equal(14);
   });
   it('Check nullified commitments', async () => {
-    expect(res.Escrow[6].body.commitments[0].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[1].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[2].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[3].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[4].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[5].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[6].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[7].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[8].isNullified).to.equal(false);
-    expect(res.Escrow[7].body.commitments[0].isNullified).to.equal(false);
-    expect(res.Escrow[7].body.commitments[1].isNullified).to.equal(false);
-    expect(res.Escrow[8].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[1].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[2].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[3].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[4].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[5].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[6].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[7].isNullified).to.equal(true);
+    expect(res.Escrow[7].body.commitments[8].isNullified).to.equal(false);
+    expect(res.Escrow[8].body.commitments[0].isNullified).to.equal(false);
     expect(res.Escrow[8].body.commitments[1].isNullified).to.equal(false);
+    expect(res.Escrow[9].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[9].body.commitments[1].isNullified).to.equal(false);
   });
   it('Check value of final commitment', async () => {
-    expect(parseInt(res.Escrow[6].body.commitments[8].preimage.value)).to.equal(27);
-    expect(parseInt(res.Escrow[7].body.commitments[0].preimage.value)).to.equal(13);
-    expect(parseInt(res.Escrow[7].body.commitments[1].preimage.value)).to.equal(1);
-    expect(parseInt(res.Escrow[8].body.commitments[0].preimage.value)).to.equal(25);
-    expect(parseInt(res.Escrow[8].body.commitments[1].preimage.value)).to.equal(44);
+    expect(
+      parseInt(res.Escrow[7].body.commitments[8].preimage.value, 10),
+    ).to.equal(27);
+    expect(
+      parseInt(res.Escrow[8].body.commitments[0].preimage.value, 10),
+    ).to.equal(13);
+    expect(
+      parseInt(res.Escrow[8].body.commitments[1].preimage.value, 10),
+    ).to.equal(1);
+    expect(
+      parseInt(res.Escrow[9].body.commitments[0].preimage.value, 10),
+    ).to.equal(25);
+    expect(
+      parseInt(res.Escrow[9].body.commitments[1].preimage.value, 10),
+    ).to.equal(44);
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
-    expect(res.Escrow[10].body.commitments.length).to.equal(13);
-    expect(res.Escrow[11].body.commitments[0].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[1].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[2].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[3].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[4].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[5].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[6].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[7].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[8].isNullified).to.equal(false);
-    expect(res.Escrow[12].body.commitments[0].isNullified).to.equal(false);
-    expect(res.Escrow[12].body.commitments[1].isNullified).to.equal(false);
-    expect(res.Escrow[13].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments.length).to.equal(13);
+    expect(res.Escrow[12].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[1].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[2].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[3].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[4].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[5].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[6].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[7].isNullified).to.equal(true);
+    expect(res.Escrow[12].body.commitments[8].isNullified).to.equal(false);
+    expect(res.Escrow[13].body.commitments[0].isNullified).to.equal(false);
     expect(res.Escrow[13].body.commitments[1].isNullified).to.equal(false);
-    expect(res.Escrow[14].body.tx.event).to.equal('NewLeaves');
+    expect(res.Escrow[14].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[14].body.commitments[1].isNullified).to.equal(false);
+    expect(res.Escrow[15].body.tx.event).to.equal('NewLeaves');
   });
 });
 
@@ -827,30 +975,64 @@ describe('NFT_Escrow Zapp', () => {
     expect(res.NFT_Escrow[0].body.tx.event).to.equal('NewLeaves');
     expect(res.NFT_Escrow[1].body.tx.event).to.equal('NewLeaves');
     expect(res.NFT_Escrow[2].body.tx.event).to.equal('NewLeaves');
+    expect(res.NFT_Escrow[3].body.tx.event).to.equal('NewLeaves');
+    expect(res.NFT_Escrow[5].body.tx.event).to.equal('NewLeaves');
+    expect(res.NFT_Escrow[6].body.tx.event).to.equal('NewLeaves');
   });
   it('MinLeaf Index check', async () => {
-    expect(parseInt(res.NFT_Escrow[0].body.tx.returnValues.minLeafIndex)).to.equal(0);
-    expect(parseInt(res.NFT_Escrow[1].body.tx.returnValues.minLeafIndex)).to.equal(1);
-    expect(parseInt(res.NFT_Escrow[2].body.tx.returnValues.minLeafIndex)).to.equal(2);
+    expect(
+      parseInt(res.NFT_Escrow[0].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(0);
+    expect(
+      parseInt(res.NFT_Escrow[1].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(1);
+    expect(
+      parseInt(res.NFT_Escrow[2].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(2);
+    expect(
+      parseInt(res.NFT_Escrow[3].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(3);
+    expect(
+      parseInt(res.NFT_Escrow[5].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(4);
+    expect(
+      parseInt(res.NFT_Escrow[6].body.tx.returnValues.minLeafIndex, 10),
+    ).to.equal(5);
   });
   it('Check number of commitments', async () => {
-    expect(res.NFT_Escrow[4].body.commitments.length).to.equal(3);
+    expect(res.NFT_Escrow[7].body.commitments.length).to.equal(6);
   });
   it('Check nullified commitments', async () => {
-    expect(res.NFT_Escrow[5].body.commitments[0].isNullified).to.equal(true);
-    expect(res.NFT_Escrow[5].body.commitments[1].isNullified).to.equal(false);
-    expect(res.NFT_Escrow[6].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[8].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[8].body.commitments[1].isNullified).to.equal(false);
+    expect(res.NFT_Escrow[9].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[10].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[10].body.commitments[1].isNullified).to.equal(false);
   });
   it('Check values of commitment', async () => {
-    expect(parseInt(res.NFT_Escrow[5].body.commitments[0].preimage.value)).to.equal(1390849295786071768276380950238675083608645509734);
-    expect(parseInt(res.NFT_Escrow[5].body.commitments[1].preimage.value)).to.equal(235);
-    expect(parseInt(res.NFT_Escrow[6].body.commitments[0].preimage.value)).to.equal(1390849295786071768276380950238675083608645509734);
+    expect(
+      parseInt(res.NFT_Escrow[8].body.commitments[0].preimage.value, 10),
+    ).to.equal(1390849295786071768276380950238675083608645509734);
+    expect(
+      parseInt(res.NFT_Escrow[8].body.commitments[1].preimage.value, 10),
+    ).to.equal(235);
+    expect(
+      parseInt(res.NFT_Escrow[9].body.commitments[0].preimage.value, 10),
+    ).to.equal(1390849295786071768276380950238675083608645509734);
+    expect(
+      parseInt(res.NFT_Escrow[10].body.commitments[0].preimage.value, 10),
+    ).to.equal(1390849295786071768276380950238675083608645509734);
+    expect(
+      parseInt(res.NFT_Escrow[10].body.commitments[1].preimage.value, 10),
+    ).to.equal(578);
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
-    expect(res.NFT_Escrow[8].body.commitments.length).to.equal(3);
-    expect(res.NFT_Escrow[9].body.commitments[0].isNullified).to.equal(true);
-    expect(res.NFT_Escrow[9].body.commitments[1].isNullified).to.equal(false);
-    expect(res.NFT_Escrow[10].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[12].body.commitments.length).to.equal(6);
+    expect(res.NFT_Escrow[13].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[13].body.commitments[1].isNullified).to.equal(false);
+    expect(res.NFT_Escrow[14].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[15].body.commitments[0].isNullified).to.equal(true);
+    expect(res.NFT_Escrow[15].body.commitments[1].isNullified).to.equal(false);
   });
 });
 

--- a/apitest.js
+++ b/apitest.js
@@ -222,6 +222,7 @@ const apiRequests_Escrow = [
   { method: 'post', endpoint: '/deposit', data: { amount: 19 } },
   { method: 'post', endpoint: '/transfer', data: { recipient: 235, amount: 13 } },
   { method: 'post', endpoint: '/withdraw', data: { amount: 3 } },
+  { method: 'post', endpoint: '/transferFrom', data: {sender: '1390849295786071768276380950238675083608645509734', recipient: 235, amount: 1 } },
   { method: 'get', endpoint: '/getAllCommitments' },
   { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'balances', mappingKey: '1390849295786071768276380950238675083608645509734'} },
   { method: 'get', endpoint: '/getCommitmentsByVariableName', data: { name: 'balances', mappingKey: '235'} },
@@ -665,45 +666,51 @@ describe('Escrow Zapp', () => {
     expect(res.Escrow[1].body.tx.event).to.equal('NewLeaves');
     expect(res.Escrow[2].body.tx.event).to.equal('NewLeaves');
     expect(res.Escrow[3].body.tx.event).to.equal('NewLeaves');
+    expect(res.Escrow[4].body.tx.event).to.equal('NewLeaves');
   });
   it('MinLeaf Index check', async () => {
     expect(parseInt(res.Escrow[0].body.tx.returnValues.minLeafIndex)).to.equal(0);
     expect(parseInt(res.Escrow[1].body.tx.returnValues.minLeafIndex)).to.equal(2);
     expect(parseInt(res.Escrow[2].body.tx.returnValues.minLeafIndex)).to.equal(4);
     expect(parseInt(res.Escrow[3].body.tx.returnValues.minLeafIndex)).to.equal(8);
+    expect(parseInt(res.Escrow[4].body.tx.returnValues.minLeafIndex)).to.equal(9);
   });
   it('Check number of commitments', async () => {
-    expect(res.Escrow[4].body.commitments.length).to.equal(9);
+    expect(res.Escrow[5].body.commitments.length).to.equal(11);
   });
   it('Check nullified commitments', async () => {
-    expect(res.Escrow[5].body.commitments[0].isNullified).to.equal(true);
-    expect(res.Escrow[5].body.commitments[1].isNullified).to.equal(true);
-    expect(res.Escrow[5].body.commitments[2].isNullified).to.equal(true);
-    expect(res.Escrow[5].body.commitments[3].isNullified).to.equal(true);
-    expect(res.Escrow[5].body.commitments[4].isNullified).to.equal(true);
-    expect(res.Escrow[5].body.commitments[5].isNullified).to.equal(false);
-    expect(res.Escrow[6].body.commitments[0].isNullified).to.equal(false);
-    expect(res.Escrow[7].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[1].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[2].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[3].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[4].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[5].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[6].isNullified).to.equal(false);
+    expect(res.Escrow[7].body.commitments[0].isNullified).to.equal(false);
     expect(res.Escrow[7].body.commitments[1].isNullified).to.equal(false);
+    expect(res.Escrow[8].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[8].body.commitments[1].isNullified).to.equal(false);
   });
   it('Check value of final commitment', async () => {
-    expect(parseInt(res.Escrow[5].body.commitments[5].preimage.value)).to.equal(28);
-    expect(parseInt(res.Escrow[6].body.commitments[0].preimage.value)).to.equal(13);
-    expect(parseInt(res.Escrow[7].body.commitments[0].preimage.value)).to.equal(25);
-    expect(parseInt(res.Escrow[7].body.commitments[1].preimage.value)).to.equal(44);
+    expect(parseInt(res.Escrow[6].body.commitments[5].preimage.value)).to.equal(27);
+    expect(parseInt(res.Escrow[7].body.commitments[0].preimage.value)).to.equal(14);
+    expect(parseInt(res.Escrow[8].body.commitments[0].preimage.value)).to.equal(25);
+    expect(parseInt(res.Escrow[8].body.commitments[1].preimage.value)).to.equal(44);
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
-    expect(res.Escrow[9].body.commitments.length).to.equal(9);
-    expect(res.Escrow[10].body.commitments[0].isNullified).to.equal(true);
-    expect(res.Escrow[10].body.commitments[1].isNullified).to.equal(true);
-    expect(res.Escrow[10].body.commitments[2].isNullified).to.equal(true);
-    expect(res.Escrow[10].body.commitments[3].isNullified).to.equal(true);
-    expect(res.Escrow[10].body.commitments[4].isNullified).to.equal(true);
-    expect(res.Escrow[10].body.commitments[5].isNullified).to.equal(false);
-    expect(res.Escrow[11].body.commitments[0].isNullified).to.equal(false);
-    expect(res.Escrow[12].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[10].body.commitments.length).to.equal(11);
+    expect(res.Escrow[11].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[1].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[2].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[3].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[4].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[5].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[6].isNullified).to.equal(false);
+    expect(res.Escrow[12].body.commitments[0].isNullified).to.equal(false);
     expect(res.Escrow[12].body.commitments[1].isNullified).to.equal(false);
-    expect(res.Escrow[13].body.tx.event).to.equal('NewLeaves');
+    expect(res.Escrow[13].body.commitments[0].isNullified).to.equal(true);
+    expect(res.Escrow[13].body.commitments[1].isNullified).to.equal(false);
+    expect(res.Escrow[14].body.tx.event).to.equal('NewLeaves');
   });
 });
 

--- a/apitest.js
+++ b/apitest.js
@@ -811,7 +811,7 @@ describe('Escrow Zapp', () => {
     ).to.equal(9);
     expect(
       parseInt(res.Escrow[5].body.tx.returnValues.minLeafIndex, 10),
-    ).to.equal(10);
+    ).to.equal(12);
   });
   it('Check number of commitments', async () => {
     expect(res.Escrow[6].body.commitments.length).to.equal(14);

--- a/apitest.js
+++ b/apitest.js
@@ -409,7 +409,7 @@ const apiRequests_NFT_Escrow = [
     data: {
       sender: '1390849295786071768276380950238675083608645509734',
       recipient: 578,
-      amount: 23456789,
+      tokenId: 23456789,
     },
   },
   { method: 'get', endpoint: '/getAllCommitments' },
@@ -808,10 +808,10 @@ describe('Escrow Zapp', () => {
     ).to.equal(8);
     expect(
       parseInt(res.Escrow[4].body.tx.returnValues.minLeafIndex, 10),
-    ).to.equal(11);
+    ).to.equal(9);
     expect(
       parseInt(res.Escrow[5].body.tx.returnValues.minLeafIndex, 10),
-    ).to.equal(12);
+    ).to.equal(10);
   });
   it('Check number of commitments', async () => {
     expect(res.Escrow[6].body.commitments.length).to.equal(14);
@@ -849,7 +849,7 @@ describe('Escrow Zapp', () => {
     ).to.equal(44);
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
-    expect(res.Escrow[11].body.commitments.length).to.equal(13);
+    expect(res.Escrow[11].body.commitments.length).to.equal(14);
     expect(res.Escrow[12].body.commitments[0].isNullified).to.equal(true);
     expect(res.Escrow[12].body.commitments[1].isNullified).to.equal(true);
     expect(res.Escrow[12].body.commitments[2].isNullified).to.equal(true);

--- a/apitest.js
+++ b/apitest.js
@@ -1129,11 +1129,11 @@ describe('Swap Zapp', () => {
   it('Check number of commitments', async () => {
     expect(res.Swap[2].body.commitments.length).to.equal(4);
     expect(res.Swap[4].body.commitments.length).to.equal(7);
-    expect(res.Swap[6].body.commitments.length).to.equal(12);
+    expect(res.Swap[6].body.commitments.length).to.equal(11);
   });
 
   it('Check nullified commitments', async () => {
-    expect(res.Swap[2].body.commitments[0].isNullified).to.equal(false);
+    expect(res.Swap[2].body.commitments[0].isNullified).to.equal(true);
     expect(res.Swap[2].body.commitments[1].isNullified).to.equal(false);
     expect(res.Swap[2].body.commitments[2].isNullified).to.equal(false);
     expect(res.Swap[2].body.commitments[3].isNullified).to.equal(false);
@@ -1157,12 +1157,11 @@ describe('Swap Zapp', () => {
     expect(res.Swap[6].body.commitments[8].isNullified).to.equal(false);
     expect(res.Swap[6].body.commitments[9].isNullified).to.equal(false);
     expect(res.Swap[6].body.commitments[10].isNullified).to.equal(false);
-    expect(res.Swap[6].body.commitments[11].isNullified).to.equal(false);
   });
 
   it('Check value of final commitment', async () => {
     expect(parseInt(res.Swap[6].body.commitments[0].preimage.value)).to.equal(100); // deposit 1
-    expect(parseInt(res.Swap[6].body.commitments[2].preimage.value)).to.equal(100); // deposit 2
+    expect(parseInt(res.Swap[6].body.commitments[2].preimage.value)).to.equal(200); // deposit 2
     expect(res.Swap[6].body.commitments[4].name).to.equal("balances");
     expect(parseInt(res.Swap[6].body.commitments[4].preimage.value)).to.equal(170); // startSwap balance: 200-30
     expect(res.Swap[6].body.commitments[6].name).to.equal("swapProposals");

--- a/apitest.js
+++ b/apitest.js
@@ -673,10 +673,10 @@ describe('Escrow Zapp', () => {
     expect(parseInt(res.Escrow[1].body.tx.returnValues.minLeafIndex)).to.equal(2);
     expect(parseInt(res.Escrow[2].body.tx.returnValues.minLeafIndex)).to.equal(4);
     expect(parseInt(res.Escrow[3].body.tx.returnValues.minLeafIndex)).to.equal(8);
-    expect(parseInt(res.Escrow[4].body.tx.returnValues.minLeafIndex)).to.equal(9);
+    expect(parseInt(res.Escrow[4].body.tx.returnValues.minLeafIndex)).to.equal(11);
   });
   it('Check number of commitments', async () => {
-    expect(res.Escrow[5].body.commitments.length).to.equal(11);
+    expect(res.Escrow[5].body.commitments.length).to.equal(13);
   });
   it('Check nullified commitments', async () => {
     expect(res.Escrow[6].body.commitments[0].isNullified).to.equal(true);
@@ -685,27 +685,32 @@ describe('Escrow Zapp', () => {
     expect(res.Escrow[6].body.commitments[3].isNullified).to.equal(true);
     expect(res.Escrow[6].body.commitments[4].isNullified).to.equal(true);
     expect(res.Escrow[6].body.commitments[5].isNullified).to.equal(true);
-    expect(res.Escrow[6].body.commitments[6].isNullified).to.equal(false);
+    expect(res.Escrow[6].body.commitments[6].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[7].isNullified).to.equal(true);
+    expect(res.Escrow[6].body.commitments[8].isNullified).to.equal(false);
     expect(res.Escrow[7].body.commitments[0].isNullified).to.equal(false);
     expect(res.Escrow[7].body.commitments[1].isNullified).to.equal(false);
     expect(res.Escrow[8].body.commitments[0].isNullified).to.equal(true);
     expect(res.Escrow[8].body.commitments[1].isNullified).to.equal(false);
   });
   it('Check value of final commitment', async () => {
-    expect(parseInt(res.Escrow[6].body.commitments[5].preimage.value)).to.equal(27);
-    expect(parseInt(res.Escrow[7].body.commitments[0].preimage.value)).to.equal(14);
+    expect(parseInt(res.Escrow[6].body.commitments[8].preimage.value)).to.equal(27);
+    expect(parseInt(res.Escrow[7].body.commitments[0].preimage.value)).to.equal(13);
+    expect(parseInt(res.Escrow[7].body.commitments[1].preimage.value)).to.equal(1);
     expect(parseInt(res.Escrow[8].body.commitments[0].preimage.value)).to.equal(25);
     expect(parseInt(res.Escrow[8].body.commitments[1].preimage.value)).to.equal(44);
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
-    expect(res.Escrow[10].body.commitments.length).to.equal(11);
+    expect(res.Escrow[10].body.commitments.length).to.equal(13);
     expect(res.Escrow[11].body.commitments[0].isNullified).to.equal(true);
     expect(res.Escrow[11].body.commitments[1].isNullified).to.equal(true);
     expect(res.Escrow[11].body.commitments[2].isNullified).to.equal(true);
     expect(res.Escrow[11].body.commitments[3].isNullified).to.equal(true);
     expect(res.Escrow[11].body.commitments[4].isNullified).to.equal(true);
     expect(res.Escrow[11].body.commitments[5].isNullified).to.equal(true);
-    expect(res.Escrow[11].body.commitments[6].isNullified).to.equal(false);
+    expect(res.Escrow[11].body.commitments[6].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[7].isNullified).to.equal(true);
+    expect(res.Escrow[11].body.commitments[8].isNullified).to.equal(false);
     expect(res.Escrow[12].body.commitments[0].isNullified).to.equal(false);
     expect(res.Escrow[12].body.commitments[1].isNullified).to.equal(false);
     expect(res.Escrow[13].body.commitments[0].isNullified).to.equal(true);

--- a/src/boilerplate/circuit/zokrates/raw/BoilerplateGenerator.ts
+++ b/src/boilerplate/circuit/zokrates/raw/BoilerplateGenerator.ts
@@ -16,11 +16,13 @@ class BoilerplateGenerator {
   PoKoSK = {
     importStatements(): string[] {
       return [
-      `from "ecc/babyjubjubParams" import main as curveParams`,
-      `from "ecc/edwardsScalarMult" import main as scalarMult`,
-      `from "ecc/edwardsCompress" import main as edwardsCompress`,
-      `from "utils/pack/bool/pack256.zok" import main as bool_256_to_field`,
-      `from "utils/pack/bool/nonStrictUnpack256.zok" import main as field_to_bool_256`,
+        `from "ecc/babyjubjubParams" import main as curveParams`,
+        `from "ecc/edwardsScalarMult" import main as scalarMult`,
+        `from "ecc/edwardsCompress" import main as edwardsCompress`,
+        `from "utils/pack/bool/pack256.zok" import main as bool_256_to_field`,
+        `from "utils/pack/bool/nonStrictUnpack256.zok" import main as field_to_bool_256`,
+        `from "utils/casts/u64_to_field.zok" import main as u64_to_field`,
+        `from "utils/casts/field_to_u64.zok" import main as field_to_u64`,
       ];
     },
 

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -14,6 +14,7 @@ import { sharedSecretKey } from './number-theory.mjs';
 import { generateProof } from './zokrates.mjs';
 import { SumType, reduceTree, toBinArray, poseidonConcatHash,} from './smt_utils.mjs';
 import { hlt } from './hash-lookup.mjs';
+import { registerKey } from './contract.mjs';
 
 const { MONGO_URL, COMMITMENTS_DB, COMMITMENTS_COLLECTION } = config;
 const { generalise } = gen;
@@ -821,6 +822,8 @@ export async function getSharedSecretskeys(
   _recipientAddress,
   _recipientPublicKey = 0,
 ) {
+  if (!fs.existsSync(keyDb))
+                    await registerKey(utils.randomHex(31), null, false);
   const keys = JSON.parse(
     fs.readFileSync(keyDb, 'utf-8', err => {
       console.log(err);

--- a/src/codeGenerators/circuit/zokrates/toCircuit.ts
+++ b/src/codeGenerators/circuit/zokrates/toCircuit.ts
@@ -304,9 +304,36 @@ codeGeneratorState.wrapperFunctions.set(functionName, wrapperFunction);
       return `${codeGenerator(node.initialValue, codeGeneratorState)} = ${codeGenerator(node.subExpression, codeGeneratorState)} ${node.operator[0]} 1;`;
 
     case 'BinaryOperation':
-      return `${codeGenerator(node.leftExpression, codeGeneratorState)} ${node.operator} ${codeGenerator(
-        node.rightExpression, codeGeneratorState,
-      )}`;
+      if (node.operator === '/') {
+        let leftExpression: string;
+        let rightExpression: string;
+        if (node.leftExpression.nodeType === 'Literal') {
+          leftExpression = `${codeGenerator(
+            node.leftExpression,
+            codeGeneratorState,
+          )}u64`;
+        } else {
+          leftExpression = `field_to_u64(${codeGenerator(
+            node.leftExpression,
+            codeGeneratorState,
+          )})`;
+        }
+        if (node.rightExpression.nodeType === 'Literal') {
+          rightExpression = `${codeGenerator(
+            node.rightExpression,
+            codeGeneratorState,
+          )}u64`;
+        } else {
+          rightExpression = `field_to_u64(${codeGenerator(
+            node.rightExpression,
+            codeGeneratorState,
+          )})`;
+        }
+        return `u64_to_field(${leftExpression} ${node.operator} ${rightExpression})`;
+      }
+      return `${codeGenerator(node.leftExpression, codeGeneratorState)} ${
+        node.operator
+      } ${codeGenerator(node.rightExpression, codeGeneratorState)}`;
 
     case 'Identifier':
       return node.name;

--- a/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
@@ -179,18 +179,25 @@ export default function codeGenerator(node: any, options: any = {}): any {
       }
 
     case 'BinaryOperation':
-      return `${codeGenerator(node.leftExpression, { lhs: options.condition })} ${
-        node.operator
-      } ${codeGenerator(node.rightExpression)}`;
+      if (node.operator === '/') {
+        return `Math.floor(${codeGenerator(node.leftExpression, {
+          lhs: options.condition,
+        })} ${node.operator} ${codeGenerator(node.rightExpression)})`;
+      }
+      return `${codeGenerator(node.leftExpression, {
+        lhs: options.condition,
+      })} ${node.operator} ${codeGenerator(node.rightExpression)}`;
 
     case 'TupleExpression':
-      if(node.components.length !== 0)
-      return `(${node.components.map(codeGenerator).join(` `)})`;
+      if (node.components.length !== 0)
+        return `(${node.components.map(codeGenerator).join(` `)})`;
       return ` `;
 
     case 'IfStatement': {
-        let comment = (node.inPreStatements)  ? "// some public statements of this if statement have been moved to pre-statements here, any other statements appear later" : '';
-        // We need to declare some variables before the if statement begins (because they are used outside the if statement). 
+      const comment = node.inPreStatements
+        ? '// some public statements of this if statement have been moved to pre-statements here, any other statements appear later'
+        : '';
+      // We need to declare some variables before the if statement begins (because they are used outside the if statement).
         let preIfStatements = node.trueBody.filter((node: any) => node.outsideIf).concat(node.falseBody.filter((node: any) => node.outsideIf));
         let newPreIfStatements = [];
         preIfStatements.forEach((node: any) => {

--- a/test/contracts/user-friendly-tests/Escrow.zol
+++ b/test/contracts/user-friendly-tests/Escrow.zol
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: CC0
 
-// TARGET CONTRACT FOR PHASE 2 OF DEVELOPMENT:
-
 pragma solidity ^0.8.0;
 
 import "./Escrow-imports/IERC20.sol";
@@ -9,6 +7,7 @@ import "./Escrow-imports/IERC20.sol";
 contract Escrow {
 
     secret mapping(address => uint256) public balances;
+    secret mapping(address => address) public approvals;
     secret uint256 public tokens;
     IERC20 public erc20;
 
@@ -24,7 +23,21 @@ contract Escrow {
     }
 
     function transfer(secret address recipient, secret uint256 amount) public {
+        require(recipient != address(0), "Escrow: transfer to the zero address");
         balances[msg.sender] -= amount;
+        encrypt unknown balances[recipient] += amount;
+    }
+
+    function approve(secret address approvedAddress) public {
+        require(approvedAddress != address(0), "Escrow: approve to the zero address");
+        approvals[msg.sender] = approvedAddress;
+    }
+
+    function transferFrom(secret address sender, secret address recipient, secret uint256 amount) public {
+        require(approvals[msg.sender] == sender);
+        require(recipient != address(0), "Escrow: approve to the zero address");
+        require(sender != address(0), "Escrow: approve from the zero address");
+        balances[sender] -= amount;
         encrypt unknown balances[recipient] += amount;
     }
 

--- a/test/contracts/user-friendly-tests/NFT_Escrow.zol
+++ b/test/contracts/user-friendly-tests/NFT_Escrow.zol
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: CC0
 
-// TARGET CONTRACT FOR PHASE 2 OF DEVELOPMENT:
-
 pragma solidity ^0.8.0;
 
 import "./Escrow-imports/IERC721.sol";
@@ -9,6 +7,7 @@ import "./Escrow-imports/IERC721.sol";
 contract NFT_Escrow {
 
     secret mapping(uint256 => address) public tokenOwners; // mapped-to by a tokenId
+    secret mapping(address => address) public approvals;
     IERC721 public erc721;
 
     constructor(address _erc721) {
@@ -23,6 +22,19 @@ contract NFT_Escrow {
 
     function transfer(secret address recipient, secret uint256 tokenId) public {
         require(tokenOwners[tokenId] == msg.sender);
+        require(recipient != address(0), "NFT_Escrow: transfer to the zero address");
+        tokenOwners[tokenId] = recipient;
+    }
+
+    function approve(secret address approvedAddress) public {
+        require(approvedAddress != address(0), "Escrow: approve to the zero address");
+        approvals[msg.sender] = approvedAddress;
+    }
+
+    function transferFrom(secret address sender, secret address recipient, secret uint256 tokenId) public {
+        require(approvals[msg.sender] == sender);
+        require(recipient != address(0), "NFT_Escrow: transfer to the zero address");
+        require(sender != address(0), "NFT_Escrow: transfer from the zero address");
         tokenOwners[tokenId] = recipient;
     }
 

--- a/test/contracts/user-friendly-tests/Swap.zol
+++ b/test/contracts/user-friendly-tests/Swap.zol
@@ -8,7 +8,6 @@ contract Swap {
     secret mapping(uint256 => address) public tokenOwners;
     struct swapStruct{
         uint256 swapAmountSent;
-        uint256 swapAmountRecieved;
         uint256 swapTokenSent;
         uint256 swapTokenRecieved;
         address swapInitiator;
@@ -23,30 +22,27 @@ contract Swap {
         reinitialisable tokenOwners[tokenId] = msg.sender;
     }
 
-    function startSwap(secret address sharedAddress,  secret uint256 amountSent, secret uint256 tokenIdSent, secret uint256 amountRecieved, secret uint256 tokenIdRecieved) public {
+    function startSwap(secret address sharedAddress,  secret uint256 amountSent, secret uint256 tokenIdSent, secret uint256 tokenIdRecieved) public {
         
            require(swapProposals[sharedAddress].pendingStatus == 0);
             swapProposals[sharedAddress].swapAmountSent += amountSent;
             balances[msg.sender] -= amountSent; 
             tokenOwners[tokenIdSent] = sharedAddress;
             swapProposals[sharedAddress].swapTokenSent = tokenIdSent;
-            swapProposals[sharedAddress].swapAmountRecieved += amountRecieved;
             swapProposals[sharedAddress].swapTokenRecieved = tokenIdRecieved;
             swapProposals[sharedAddress].swapInitiator = msg.sender;
             swapProposals[sharedAddress].pendingStatus = 1;
        
     }
 
-    function completeSwap(secret address counterParty, secret address sharedAddress,  secret uint256 amountSent, secret uint256 tokenIdSent, secret uint256 amountRecieved, secret uint256 tokenIdRecieved) public {
+    function completeSwap(secret address counterParty, secret address sharedAddress, secret uint256 tokenIdSent, secret uint256 amountRecieved, secret uint256 tokenIdRecieved) public {
            
-           require(swapProposals[sharedAddress].swapAmountRecieved == amountSent && swapProposals[sharedAddress].swapTokenRecieved == tokenIdSent);
+           require(swapProposals[sharedAddress].swapTokenRecieved == tokenIdSent);
            require(swapProposals[sharedAddress].swapAmountSent == amountRecieved && swapProposals[sharedAddress].swapTokenSent == tokenIdRecieved);
            require(swapProposals[sharedAddress].pendingStatus == 1);
            require(counterParty == swapProposals[sharedAddress].swapInitiator);
             swapProposals[sharedAddress].swapAmountSent -= amountRecieved;
-            swapProposals[sharedAddress].swapAmountRecieved -= amountSent;
-            balances[msg.sender] +=  amountRecieved - amountSent; 
-            unknown balances[counterParty] += amountSent; 
+            balances[msg.sender] +=  amountRecieved; 
             tokenOwners[tokenIdSent] = counterParty;
             
             tokenOwners[tokenIdRecieved] = msg.sender;
@@ -63,7 +59,6 @@ contract Swap {
             tokenOwners[tokenIdSent] = msg.sender;
             swapProposals[sharedAddress].swapTokenSent = 0;
             swapProposals[sharedAddress].swapTokenRecieved = 0;
-            swapProposals[sharedAddress].swapAmountRecieved = 0;
             swapProposals[sharedAddress].pendingStatus = 0;
          
     }


### PR DESCRIPTION
changes to Escrow and NFT_Escrow contracts. We introduce transferFrom, for composability, so that a transfer can be called from other contract (in this case in a standard msg.sender would be that contract). We introduce approvals to allow transferFrom to work securely. Also fixes some other unrelated bugs. 