### PR TITLE
Lyd/bytes20

### DIFF
--- a/apitest.js
+++ b/apitest.js
@@ -15,6 +15,9 @@ const { expect } = chai;
 chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 
+const parseAddressValue = value => BigInt(value);
+const expectedSenderAddress = 1390849295786071768276380950238675083608645509734n;
+
 const testedZapps = [];
 const zappLogs = new Map(); // Store logs for each zapp
 const displayedZapps = new Set(); // Track which ZApps have already had logs displayed
@@ -1254,20 +1257,20 @@ describe('NFT_Escrow Zapp', () => {
   });
   it('Check values of commitment', async () => {
     expect(
-      parseInt(res.NFT_Escrow[8].body.commitments[0].preimage.value, 10),
-    ).to.equal(1390849295786071768276380950238675083608645509734);
+      parseAddressValue(res.NFT_Escrow[8].body.commitments[0].preimage.value),
+    ).to.equal(expectedSenderAddress);
     expect(
-      parseInt(res.NFT_Escrow[8].body.commitments[1].preimage.value, 10),
-    ).to.equal(235);
+      parseAddressValue(res.NFT_Escrow[8].body.commitments[1].preimage.value),
+    ).to.equal(235n);
     expect(
-      parseInt(res.NFT_Escrow[9].body.commitments[0].preimage.value, 10),
-    ).to.equal(1390849295786071768276380950238675083608645509734);
+      parseAddressValue(res.NFT_Escrow[9].body.commitments[0].preimage.value),
+    ).to.equal(expectedSenderAddress);
     expect(
-      parseInt(res.NFT_Escrow[10].body.commitments[0].preimage.value, 10),
-    ).to.equal(1390849295786071768276380950238675083608645509734);
+      parseAddressValue(res.NFT_Escrow[10].body.commitments[0].preimage.value),
+    ).to.equal(expectedSenderAddress);
     expect(
-      parseInt(res.NFT_Escrow[10].body.commitments[1].preimage.value, 10),
-    ).to.equal(578);
+      parseAddressValue(res.NFT_Escrow[10].body.commitments[1].preimage.value),
+    ).to.equal(578n);
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
     expect(res.NFT_Escrow[12].body.commitments.length).to.equal(6);
@@ -1440,21 +1443,21 @@ describe('Swap Zapp', () => {
       parseInt(res.Swap[6].body.commitments[4].preimage.value, 10),
     ).to.equal(170); // startSwap balance: 200-30
     expect(res.Swap[6].body.commitments[6].name).to.equal("swapProposals");
-    expect(res.Swap[6].body.commitments[6].preimage.value).to.deep.equal({
-      swapAmountSent: '30',
-      swapTokenSent: '1',
-      swapTokenRecieved: '2',
-      swapInitiator: '1390849295786071768276380950238675083608645509734',
-      pendingStatus: '1',
-    });
+    expect(res.Swap[6].body.commitments[6].preimage.value.swapAmountSent).to.equal('30');
+    expect(res.Swap[6].body.commitments[6].preimage.value.swapTokenSent).to.equal('1');
+    expect(res.Swap[6].body.commitments[6].preimage.value.swapTokenRecieved).to.equal('2');
+    expect(
+      parseAddressValue(res.Swap[6].body.commitments[6].preimage.value.swapInitiator),
+    ).to.equal(expectedSenderAddress);
+    expect(res.Swap[6].body.commitments[6].preimage.value.pendingStatus).to.equal('1');
     expect(res.Swap[6].body.commitments[10].name).to.equal("swapProposals");
-    expect(res.Swap[6].body.commitments[10].preimage.value).to.deep.equal({
-      swapAmountSent: '0',
-      swapTokenSent: '1',
-      swapTokenRecieved: '2',
-      swapInitiator: '1390849295786071768276380950238675083608645509734',
-      pendingStatus: '0',
-    });
+    expect(res.Swap[6].body.commitments[10].preimage.value.swapAmountSent).to.equal('0');
+    expect(res.Swap[6].body.commitments[10].preimage.value.swapTokenSent).to.equal('1');
+    expect(res.Swap[6].body.commitments[10].preimage.value.swapTokenRecieved).to.equal('2');
+    expect(
+      parseAddressValue(res.Swap[6].body.commitments[10].preimage.value.swapInitiator),
+    ).to.equal(expectedSenderAddress);
+    expect(res.Swap[6].body.commitments[10].preimage.value.pendingStatus).to.equal('0');
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
     // Note the order of the commitments has changed because some are decrypted with the shared secret key
@@ -1481,20 +1484,20 @@ describe('Swap Zapp', () => {
       parseInt(res.Swap[8].body.commitments[4].preimage.value, 10),
     ).to.equal(170); // startSwap balance: 200-30
     expect(res.Swap[8].body.commitments[9].name).to.equal("swapProposals");
-    expect(res.Swap[8].body.commitments[9].preimage.value).to.deep.equal({
-      swapAmountSent: '30',
-      swapTokenSent: '1',
-      swapTokenRecieved: '2',
-      swapInitiator: '1390849295786071768276380950238675083608645509734',
-      pendingStatus: '1',
-    });
+    expect(res.Swap[8].body.commitments[9].preimage.value.swapAmountSent).to.equal('30');
+    expect(res.Swap[8].body.commitments[9].preimage.value.swapTokenSent).to.equal('1');
+    expect(res.Swap[8].body.commitments[9].preimage.value.swapTokenRecieved).to.equal('2');
+    expect(
+      parseAddressValue(res.Swap[8].body.commitments[9].preimage.value.swapInitiator),
+    ).to.equal(expectedSenderAddress);
+    expect(res.Swap[8].body.commitments[9].preimage.value.pendingStatus).to.equal('1');
     expect(res.Swap[8].body.commitments[10].name).to.equal("swapProposals");
-    expect(res.Swap[8].body.commitments[10].preimage.value).to.deep.equal({
-      swapAmountSent: '0',
-      swapTokenSent: '1',
-      swapTokenRecieved: '2',
-      swapInitiator: '1390849295786071768276380950238675083608645509734',
-      pendingStatus: '0',
-    });
+    expect(res.Swap[8].body.commitments[10].preimage.value.swapAmountSent).to.equal('0');
+    expect(res.Swap[8].body.commitments[10].preimage.value.swapTokenSent).to.equal('1');
+    expect(res.Swap[8].body.commitments[10].preimage.value.swapTokenRecieved).to.equal('2');
+    expect(
+      parseAddressValue(res.Swap[8].body.commitments[10].preimage.value.swapInitiator),
+    ).to.equal(expectedSenderAddress);
+    expect(res.Swap[8].body.commitments[10].preimage.value.pendingStatus).to.equal('0');
   });
 });

--- a/doc/STATUS.md
+++ b/doc/STATUS.md
@@ -70,7 +70,8 @@ Here we summarise the as of yet unsupported Solidity syntax.
   - Conditions like `if(a)` or `if(flag)` are not supported. Use explicit comparisons, e.g., `if(a == true)`.
 - **Logical expressions with mixed `&&` and `||` operators:**
   - Nested logical operators without brackets (e.g., `if(a && b || c)`) are not supported. Use brackets to clarify logic, e.g., `if((a && b) || c)`.
-- **Secret variables named `key` or starting with `_`:**
-  - Zokrates does not support secret variables named `key` or starting with an underscore (e.g., `_value`).
+- **Variables with reserved names, and secret variables starting with `_`:**
+  - Zokrates does not support variables with these names: `key`, `secretKey`, `publicKey`, `sharedSecretKey`, `sharedPublicKey`, `keys`, `instance`, `contractAddr`, `web3`, `BackupData`, `msgSender`, `msgValue`, `allInputs`, `res`, `proof`, `txData`, `txParams`, `tx`, `signed`, `sendTxn`, `encEvent`, `encBackupEvent`, `publicReturns`.
+  - Zokrates also does not support secret variables starting with an underscore (e.g., `_value`).
 - **Other limitations:**
   - The compiler will throw errors for unsupported patterns, often with suggestions for workarounds.

--- a/doc/STATUS.md
+++ b/doc/STATUS.md
@@ -24,10 +24,10 @@ Do note that `LoanSimple.zol` don't currently compile - we are actively working 
       - Constructors are supported, but be aware that the output shield contract will contain a constructor combining the `.zol` constructor and some extra functionality.
       - Functions can have any number of secret or public parameters of the types below.
       - Any number of states, secret or public:
-      - Secret states can have types `uint256`, `bool`, `address`, `mapping`, `array` (one dimensional only), `struct`, or mappings to structs (e.g., `mapping(uint256 => MyStruct)`).
-        - Keys of secret mappings can be `uint256` or `address`.
-        - Arrays are only supported with element types `address` or `uint256`.
-        - Structs can only have properties with types `uint256`, `bool` or `address`.
+      - Secret states can have types `uint256`, `bool`, `address`, `bytes20`, `mapping`, `array` (one dimensional only), `struct`, or mappings to structs (e.g., `mapping(uint256 => MyStruct)`).
+        - Keys of secret mappings can be `uint256`, `bytes20` or `address`.
+        - Arrays are only supported with element types `uint256`, `address`, or `bytes20`.
+        - Structs can only have properties with types `uint256`, `bool`, `address`, or `bytes20`.
       - All other types (e.g. `u32`), except for Enums, can be used as long as they aren't secret or interact with secret states. Enums are not supported, even if they are public and don't interact with secret states.
       - Public and secret states *can* interact within functions, but this may break the output zApp or render its privacy useless.
       - Secret states can be *overwritten* on each edit (i.e. they are whole) or *incremented* on each edit (i.e. they are partitioned) - the compiler will work this out for you based on what states are known or unknown to the caller.

--- a/doc/WRITEUP.md
+++ b/doc/WRITEUP.md
@@ -519,7 +519,7 @@ myMapping[key] = value, is stored at storage slot `hash( key, id )`
 
 #### zApps' commitment structures
 
-For our current phase of work, we support `uint256` and `address` basic types, `structs`, `arrays`, and `mapping` (including mappings to structs).
+For our current phase of work, we support `uint256`, `bool`, `address`, and `bytes20` basic types, plus `structs`, `arrays`, and `mapping` (including mappings to structs).
 
 Consider this incomplete `.zol` contract:
 

--- a/src/boilerplate/common/backup-encrypted-data-listener.mjs
+++ b/src/boilerplate/common/backup-encrypted-data-listener.mjs
@@ -252,15 +252,25 @@ export default class BackupEncryptedDataEventListener {
             eventData.returnValues.encPreimages[i];
           let { varName } = eventData.returnValues.encPreimages[i];
           const name = varName.split(' ')[0];
-          const structProperties = varName.split('props:')[1]?.trim();
+          const structMetadata = varName.split('props:')[1]?.trim();
+          const structProperties = structMetadata?.split(' types:')[0]?.trim();
+          const structTypeNames =
+            structMetadata
+              ?.split(' types:')[1]
+              ?.trim()
+              ?.split(' ')
+              .filter(Boolean) || null;
           varName = varName.split('props:')[0]?.trim();
-          let isArray = false;
-          let isStruct = false;
-          if (varName.includes(' a')) {
-            isArray = true;
-          }
-          if (varName.includes(' s')) {
-            isStruct = true;
+          const flags = varName.split(' ').slice(1);
+          const isArray = flags.includes('a');
+          const isStruct = flags.includes('s');
+          const isBytes20 = flags.includes('b20');
+          const isAddress = flags.includes('addr');
+          let commitmentType = null;
+          if (isBytes20) {
+            commitmentType = 'bytes20';
+          } else if (isAddress) {
+            commitmentType = 'address';
           }
           const plainText = decrypt(cipherText, kp.secretKey.hex(32), [
             decompressStarlightKey(generalise(ephPublicKey))[0].hex(32),
@@ -299,7 +309,9 @@ export default class BackupEncryptedDataEventListener {
           if (isStruct) {
             value = {};
             count = isArray ? 3 : 2;
-            for (const prop of structProperties.split(' ')) {
+            for (
+              const prop of structProperties?.split(' ').filter(Boolean) || []
+            ) {
               value[prop] = plainText[count];
               count++;
             }
@@ -377,6 +389,8 @@ export default class BackupEncryptedDataEventListener {
               hash: newCommitment,
               name,
               mappingKey: mappingKey?.integer,
+              type: commitmentType,
+              typeNames: structTypeNames,
               preimage: {
                 stateVarId,
                 value,

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -21,35 +21,83 @@ const { generalise } = gen;
 const keyDb =
   process.env.KEY_DB_PATH || '/app/orchestration/common/db/key.json';
 
-export function formatCommitment (commitment) {
-  let data
+const PRINTABLE_ASCII_REGEX = /^[\x20-\x7E]*$/;
+
+const formatPreimageValue = (rawValue, typeName = null) => {
+  const generalisedValue = generalise(rawValue);
+  if (typeName === 'bytes20') {
+    const asciiValue = generalisedValue.all
+      ? generalisedValue.all.ascii
+      : generalisedValue.ascii;
+    if (
+      typeof asciiValue === 'string' &&
+      PRINTABLE_ASCII_REGEX.test(asciiValue)
+    ) {
+      return asciiValue;
+    }
+    return generalisedValue.all
+      ? generalisedValue.all.hex(20)
+      : generalisedValue.hex(20);
+  }
+  if (typeName === 'address') {
+    return generalisedValue.all
+      ? generalisedValue.all.hex(32)
+      : generalisedValue.hex(32);
+  }
+  return generalisedValue.all
+    ? generalisedValue.all.integer
+    : generalisedValue.integer;
+};
+
+export function formatCommitment(commitment) {
+  let data;
   try {
     const nullifierHash = commitment.secretKey
       ? poseidonHash([
-        BigInt(commitment.preimage.stateVarId.hex(32)),
-        BigInt(commitment.secretKey.hex(32)),
-        BigInt(commitment.preimage.salt.hex(32))
-      ])
-      : ''
-    const preimage = generalise(commitment.preimage).all.hex(32)
-    preimage.value = generalise(commitment.preimage.value).all
-      ? generalise(commitment.preimage.value).all.integer
-      : generalise(commitment.preimage.value).integer
+          BigInt(commitment.preimage.stateVarId.hex(32)),
+          BigInt(commitment.secretKey.hex(32)),
+          BigInt(commitment.preimage.salt.hex(32)),
+        ])
+      : '';
+    const preimage = generalise(commitment.preimage).all.hex(32);
+    if (
+      Array.isArray(commitment.typeNames) &&
+      commitment.typeNames.length > 0
+    ) {
+      preimage.value = {};
+      const rawStructValue = commitment.preimage.value || {};
+      const structKeys = Object.keys(rawStructValue);
+      structKeys.forEach((propertyName, index) => {
+        preimage.value[propertyName] = formatPreimageValue(
+          rawStructValue[propertyName],
+          commitment.typeNames[index],
+        );
+      });
+    } else {
+      preimage.value = formatPreimageValue(
+        commitment.preimage.value,
+        commitment.type,
+      );
+    }
     data = {
       _id: commitment.hash.hex(32),
       name: commitment.name,
       source: commitment.source,
+      type: commitment.type ?? null,
+      typeNames: Array.isArray(commitment.typeNames)
+        ? commitment.typeNames
+        : null,
       mappingKey: commitment.mappingKey ? commitment.mappingKey : null,
       secretKey: commitment.secretKey ? commitment.secretKey.hex(32) : null,
       preimage,
       isNullified: commitment.isNullified,
-      nullifier: commitment.secretKey ? nullifierHash.hex(32) : null
-    }
-    logger.debug(`Storing commitment ${data._id}`)
+      nullifier: commitment.secretKey ? nullifierHash.hex(32) : null,
+    };
+    logger.debug(`Storing commitment ${data._id}`);
   } catch (error) {
-    console.error('Error --->', error)
+    console.error('Error --->', error);
   }
-  return data
+  return data;
 }
 
 export async function persistCommitment (data) {

--- a/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
@@ -38,6 +38,17 @@ const getPrivateStateValueType = (
   return null;
 };
 
+const getStructPropertyNames = (indicator: any): string[] | null => {
+  if (!indicator?.isStruct) return null;
+
+  const declaredMembers =
+    indicator?.referencingPaths?.[0]?.getStructDeclaration?.()?.members;
+  if (declaredMembers?.length) return declaredMembers.map((member: any) => member.name);
+
+  const discoveredMembers = Object.keys(indicator?.structProperties || {});
+  return discoveredMembers.length ? discoveredMembers : null;
+};
+
 /**
  * @param {string} nodeType - the type of node you'd like to build
  * @param {Object} fields - important key, value pairs to include in the node, and which enable the rest of the node's info to be derived. How do you know which data to include in `fields`? Read this function.
@@ -52,7 +63,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         accessedOnly,
         mappingKey: indicator.isMapping ? indicator.referencedKeyName || indicator.keyPath.node.name : null,
         mappingName: indicator.isMapping ? indicator.node?.name : null,
-        structProperties: indicator.isStruct ? Object.keys(indicator.structProperties) : null,
+        structProperties: getStructPropertyNames(indicator),
       };
     }
     case 'ReadPreimage': {
@@ -70,7 +81,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         isSharedSecret: indicator.isSharedSecret,
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
-        structProperties: indicator.isStruct ? Object.keys(indicator.structProperties) : null,
+        structProperties: getStructPropertyNames(indicator),
         mappingKey: indicator.isMapping ? indicator.referencedKeyName || indicator.keyPath.node.name : null,
         mappingName: indicator.isMapping ? indicator.node?.name : null,
         nullifierRequired: indicator.isNullified,
@@ -98,7 +109,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         isSharedSecret: indicator.isSharedSecret,
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
-        structProperties: indicator.isStruct ? indicator.referencingPaths[0]?.getStructDeclaration()?.members.map(m => m.name) : null,
+        structProperties: getStructPropertyNames(indicator),
         mappingKey: indicator.isMapping ? indicator.referencedKeyName || indicator.keyPath.node.name : null,
         mappingName: indicator.isMapping ? indicator.node?.name : null,
         nullifierRequired: indicator.isNullified,
@@ -130,9 +141,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         accessedOnly,
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
-        structProperties: indicator.isStruct
-          ? Object.keys(indicator.structProperties)
-          : null,
+        structProperties: getStructPropertyNames(indicator),
         mappingName: indicator.isMapping ? indicator.node?.name : null,
       };
     }
@@ -152,7 +161,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         accessedOnly,
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
-        structProperties: indicator.isStruct ? Object.keys(indicator.structProperties) : null,
+        structProperties: getStructPropertyNames(indicator),
         mappingName: indicator.isMapping ? indicator.node?.name : null,
       };
     }
@@ -176,7 +185,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
         nullifierRequired: indicator.isNullified,
-        structProperties: indicator.isStruct ? indicator.referencingPaths[0]?.getStructDeclaration()?.members.map(m => m.name) : null,
+        structProperties: getStructPropertyNames(indicator),
         isOwned: indicator.isOwned,
         mappingOwnershipType: indicator.mappingOwnershipType,
         owner: indicator.isOwned
@@ -198,7 +207,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         indicator = {},
         localMappingKey,
       } = fields;
-      const structProperties = !indicator.isStruct ? null : indicator.isAccessed ? indicator.referencingPaths[0]?.getStructDeclaration()?.members.map(m => m.name) : Object.keys(indicator.structProperties);
+      const structProperties = getStructPropertyNames(indicator);
       return {
         privateStateName,
         stateVarId: id,
@@ -238,7 +247,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
         nullifierRequired: indicator.isNullified,
-        structProperties: indicator.isStruct ? indicator.referencingPaths[0]?.getStructDeclaration()?.members.map(m => m.name) : null,
+        structProperties: getStructPropertyNames(indicator),
         isOwned: indicator.isOwned,
         mappingOwnershipType: indicator.mappingOwnershipType,
         encryptionRequired: indicator.encryptionRequired,
@@ -280,7 +289,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
         mappingName: indicator.isMapping ? indicator.node?.name : null,
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
-        structProperties: indicator.isStruct ? indicator.referencingPaths[0]?.getStructDeclaration()?.members.map(m => m.name) : null,
+        structProperties: getStructPropertyNames(indicator),
         isOwned: indicator.isOwned,
         mappingOwnershipType: indicator.mappingOwnershipType,
         encryptionRequired: indicator.encryptionRequired,

--- a/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/nodes/boilerplate-generator.ts
@@ -3,6 +3,41 @@ import { StateVariableIndicator } from '../../../../traverse/Indicator.js';
 import MappingKey from '../../../../traverse/MappingKey.js';
 import buildNode from '../../../../types/orchestration-types.js';
 
+const getValueTypeFromTypeName = (typeNameNode: any): string | null => {
+  if (!typeNameNode) return null;
+  if (typeNameNode.nodeType === 'ElementaryTypeName') return typeNameNode.name || null;
+  if (typeNameNode.nodeType === 'Mapping') return getValueTypeFromTypeName(typeNameNode.valueType);
+  if (typeNameNode.nodeType === 'ArrayTypeName') return getValueTypeFromTypeName(typeNameNode.baseType);
+  return null;
+};
+
+const getPrivateStateValueType = (
+  indicator: any,
+  isMapping: boolean,
+  isStruct: boolean,
+): any => {
+  if (isStruct) {
+    const structMembers =
+      indicator?.referencingPaths?.[0]?.getStructDeclaration?.()?.members;
+    if (!structMembers?.length) return [];
+    return structMembers
+      .map((member: any) => getValueTypeFromTypeName(member?.typeName))
+      .filter((memberType: string | null): memberType is string =>
+        Boolean(memberType),
+      );
+  }
+  if (isMapping) {
+    const containerBindingTypeName =
+      indicator?.container?.binding?.path?.node?.typeName;
+    if (containerBindingTypeName)
+      return getValueTypeFromTypeName(containerBindingTypeName);
+  }
+  const bindingTypeName = indicator?.binding?.path?.node?.typeName;
+  if (bindingTypeName) return getValueTypeFromTypeName(bindingTypeName);
+
+  return null;
+};
+
 /**
  * @param {string} nodeType - the type of node you'd like to build
  * @param {Object} fields - important key, value pairs to include in the node, and which enable the rest of the node's info to be derived. How do you know which data to include in `fields`? Read this function.
@@ -59,6 +94,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
       return {
         increment,
         stateVarId: id,
+        valueType: getPrivateStateValueType(indicator, indicator.isMapping, indicator.isStruct),
         isSharedSecret: indicator.isSharedSecret,
         isWhole: indicator.isWhole,
         isPartitioned: indicator.isPartitioned,
@@ -195,6 +231,7 @@ export function buildPrivateStateNode(nodeType: string, fields: any = {}): any {
       return {
         privateStateName,
         stateVarId: id,
+        valueType: getPrivateStateValueType(indicator, indicator.isMapping, indicator.isStruct),
         increment,
         mappingKey: indicator.isMapping ? indicator.referencedKeyName || indicator.keyPath.node.name : null,
         mappingName: indicator.isMapping ? indicator.node?.name : null,

--- a/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
+++ b/src/boilerplate/orchestration/javascript/raw/boilerplate-generator.ts
@@ -595,7 +595,7 @@ class BoilerplateGenerator {
 
 encryptBackupPreimage = {
 
-  postStatements({ stateName, stateType, structProperties, encryptionRequired, mappingName, mappingKey }): string[] {
+  postStatements({ stateName, stateType, valueType, structProperties, encryptionRequired, mappingName, mappingKey }): string[] {
     let valueName = '';
     let saltName = '';
     switch (stateType) {
@@ -631,11 +631,17 @@ encryptBackupPreimage = {
       plainText = `[BigInt(${saltName}.hex(32)), BigInt(${stateName}_stateVarId),
         ${valueName}]`;
     }
+    if (valueType === 'bytes20') varName += ` b20`;
+    if (valueType === 'address') varName += ` addr`;
     if (structProperties) varName += ` s`;
     if (stateType === 'increment') varName += ` u`;
     if (structProperties) {
       varName += ` props:`;
       varName += ` ${structProperties.join(' ')}`;
+      if (Array.isArray(valueType) && valueType.length > 0) {
+        varName += ` types:`;
+        varName += ` ${valueType.join(' ')}`;
+      }
     } 
     return[`\n\n// Encrypt pre-image for state variable ${stateName} as a backup: \n 
     let ${stateName}_ephSecretKey = generalise(utils.randomHex(31)); \n 
@@ -671,6 +677,7 @@ sendTransaction = {
     postStatements({
       stateName,
       stateType,
+      valueType,
       isSharedSecret,
       mappingName,
       mappingKey,
@@ -680,6 +687,12 @@ sendTransaction = {
       isConstructor
     }): string[] {
       let value;
+      const commitmentType = !Array.isArray(valueType) && ['bytes20', 'address'].includes(valueType)
+        ? `\n            type: '${valueType}',`
+        : '';
+      const commitmentTypeNames = Array.isArray(valueType) && valueType.length > 0
+        ? `\n            typeNames: [${valueType.map(typeName => `'${typeName}'`).join(', ')}],`
+        : '';
       const errorCatch = `\n console.log("Added commitment", newCommitment.hex(32));
       } catch (e) {
         if (e.toString().includes("E11000 duplicate key")) {
@@ -696,6 +709,8 @@ sendTransaction = {
             hash: ${stateName}_newCommitment,
             name: '${mappingName}',
             mappingKey: ${mappingKey === `` ? `null` : `${mappingKey}`},
+            ${commitmentType}
+            ${commitmentTypeNames}
             preimage: {
               \tstateVarId: generalise(${stateName}_stateVarId),
               \tvalue: ${value},
@@ -715,6 +730,8 @@ sendTransaction = {
               hash: ${stateName}_2_newCommitment,
               name: '${mappingName}',
               mappingKey: ${mappingKey === `` ? `null` : `${mappingKey}`},
+              ${commitmentType}
+              ${commitmentTypeNames}
               preimage: {
                 \tstateVarId: generalise(${stateName}_stateVarId),
                 \tvalue: ${value},
@@ -739,6 +756,8 @@ sendTransaction = {
                   hash: ${stateName}_newCommitment,
                   name: '${mappingName}',
                   mappingKey: ${mappingKey === `` ? `null` : `${mappingKey}`},
+                  ${commitmentType}
+                  ${commitmentTypeNames}
                   preimage: {
                     \tstateVarId: generalise(${stateName}_stateVarId),
                     \tvalue: ${value},

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -549,9 +549,15 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
       });
       const decStates = node.decrementedSecretStates;
       const incStates = node.incrementedSecretStates;
-      let returnParameterNames = node.returnParameters.parameters
-        .filter((paramnode: any) => (paramnode.isSecret || paramnode.typeName.name === 'bool'))
-          .map(paramnode => (paramnode.name)) || [];
+      const returnParameterNames =
+        node.returnParameters.parameters
+          .filter(
+            (paramnode: any) =>
+              paramnode.isSecret ||
+              (paramnode.typeName.name === 'bool' &&
+                (paramnode.name === 'true' || paramnode.name === 'false')),
+          )
+          .map(paramnode => paramnode.name) || [];
       returnParameterNames.forEach( (param, index) => {
         if(decStates) {
           if(decStates?.includes(param)){

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -505,12 +505,25 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
       if (node.msgSenderParam)
         lines.push(`
               \nconst msgSender = generalise(config.web3.options.defaultAccount);`);
-      if (node.msgValueParam)
-        lines.push(`
-              \nconst msgValue = 1;`);
-              else
-              lines.push(`
-              \nconst msgValue = 0;`);  
+      if (node.msgValueParam) lines.push(`\nconst msgValue = 1;`);
+      else lines.push(`\nconst msgValue = 0;`);
+      node.parameters.parameters.forEach((paramNode: any) => {
+        if (paramNode?.typeName?.name === 'bytes20') {
+          const paramName = paramNode.name;
+          lines.push(`
+            if (typeof _${paramName} === "string") {
+              if (_${paramName}.startsWith("0x")) {
+                const ${paramName}_hex = _${paramName}.slice(2);
+                if (${paramName}_hex.length > 40) {
+                  throw new Error("Invalid bytes20 input '${paramName}': hex string exceeds 20 bytes.");
+                }
+              } else if (Buffer.byteLength(_${paramName}, "utf8") > 20) {
+                throw new Error("Invalid bytes20 input '${paramName}': string exceeds 20 bytes.");
+              }
+            }
+          `);
+        }
+      });
       node.inputParameters.forEach((param: string) => {
         lines.push(`\nlet ${param} = generalise(_${param});`);
         lines.push(`\nconst ${param}_init = generalise(_${param});`);
@@ -669,6 +682,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
                   Orchestrationbp.writePreimage.postStatements({
                     stateName,
                     stateType: 'decrement',
+                    valueType: stateNode.valueType,
                     isSharedSecret: stateNode.isSharedSecret,
                     mappingName: stateNode.mappingName || stateName,
                     mappingKey: stateNode.mappingKey
@@ -687,6 +701,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
                     Orchestrationbp.writePreimage.postStatements({
                     stateName,
                     stateType: 'increment',
+                    valueType: stateNode.valueType,
                     isSharedSecret: stateNode.isSharedSecret,
                     mappingName:stateNode.mappingName || stateName,
                     mappingKey: stateNode.mappingKey
@@ -707,6 +722,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
                 Orchestrationbp.writePreimage.postStatements({
                 stateName,
                 stateType: 'whole',
+                valueType: stateNode.valueType,
                 isSharedSecret: stateNode.isSharedSecret,
                 mappingName: stateNode.mappingName || stateName,
                 mappingKey: stateNode.mappingKey
@@ -950,6 +966,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
             Orchestrationbp.encryptBackupPreimage.postStatements( {
               stateName,
               stateType,
+              valueType: stateNode.valueType,
               structProperties: stateNode.structProperties,
               encryptionRequired: stateNode.encryptionRequired,
               mappingName: stateNode.mappingName || stateName,

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -989,7 +989,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
             lines.push(`${input.name}_init.all.integer`);
           } else if(input.isBool) {
             lines.push(`parseInt(${input.name}_init.integer, 10)`);
-          } else if(input.isAddress) {
+          } else if(input.isAddress || input.isBytes20) {
             lines.push(`${input.name}_init.hex(20)`);
           }
           else {
@@ -1027,7 +1027,7 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
               publicInputs.push(`${input.name}: ${input.name}.all.integer`);
             } else if(input.isBool) {
               publicInputs.push(`${input.name}: parseInt(${input.name}.integer, 10)`);
-            } else if(input.isAddress) {
+            } else if(input.isAddress || input.isBytes20) {
               publicInputs.push(`${input.name}: ${input.name}.hex(20)`);
             }
             else {
@@ -1122,10 +1122,9 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
               lines.push(`${input.name}: ${input.name}.all.integer`);
             } else if(input.isBool) {
               lines.push(`${input.name}: parseInt(${input.name}.integer, 10)`);
-            } else if(input.isAddress) {
+            } else if(input.isAddress || input.isBytes20) {
               lines.push(`${input.name}: ${input.name}.hex(20)`);
-            }
-            else {
+            } else {
               lines.push(`${input}: ${input}.integer`);
             }           
           });
@@ -1150,10 +1149,9 @@ export const OrchestrationCodeBoilerPlate: any = (node: any) => {
             lines.push(`${input.name}.all.integer`);
           } else if(input.isBool) {
             lines.push(`parseInt(${input.name}.integer, 10)`);
-          } else if(input.isAddress) {
+          } else if(input.isAddress || input.isBytes20) {
             lines.push(`${input.name}.hex(20)`);
-          }
-          else {
+          } else {
             lines.push(`${input}.integer`);
           }           
         });

--- a/src/codeGenerators/orchestration/files/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/files/toOrchestration.ts
@@ -687,18 +687,27 @@ const prepareBackupVariable = (node: any) => {
         let ephPublicKey = log.returnValues.encPreimages[i].ephPublicKey;
         let varName = log.returnValues.encPreimages[i].varName;
         let name = varName.split(" ")[0];
-        const structProperties = varName.split("props:")[1]?.trim();
+        const structMetadata = varName.split("props:")[1]?.trim();
+        const structProperties = structMetadata?.split(" types:")[0]?.trim();
+        const structTypeNames = structMetadata
+          ?.split(" types:")[1]
+          ?.trim()
+          ?.split(" ")
+          ?.filter(Boolean) || null;
         varName = varName.split("props:")[0]?.trim();
         if (requestedName !== name) {
           continue;
         }
-        let isArray = false;
-        let isStruct = false;
-        if (varName.includes(" a")) {
-          isArray = true;
-        } 
-        if (varName.includes(" s")) {
-          isStruct = true;
+        const flags = varName.split(" ").slice(1);
+        const isArray = flags.includes("a");
+        const isStruct = flags.includes("s");
+        const isBytes20 = flags.includes("b20");
+        const isAddress = flags.includes("addr");
+        let commitmentType = null;
+        if (isBytes20) {
+          commitmentType = "bytes20";
+        } else if (isAddress) {
+          commitmentType = "address";
         }
         const plainText = decrypt(
           cipherText,
@@ -739,7 +748,7 @@ const prepareBackupVariable = (node: any) => {
         if (isStruct){
           value = {};
           let count = isArray ? 3 : 2;
-          for (const prop of structProperties.split(" ")) {
+          for (const prop of structProperties?.split(" ").filter(Boolean) || []) {
             value[prop] = plainText[count];
             count++;
           }
@@ -803,6 +812,8 @@ const prepareBackupVariable = (node: any) => {
           hash: newCommitment,
           name: name,
           mappingKey: mappingKey?.integer,
+          type: commitmentType,
+          typeNames: structTypeNames,
           preimage: {
             stateVarId: stateVarId,
             value: value,
@@ -913,15 +924,24 @@ const prepareBackupDataRetriever = (node: any) => {
           let ephPublicKey = log.returnValues.encPreimages[i].ephPublicKey;
           let varName = log.returnValues.encPreimages[i].varName;
           let name = varName.split(" ")[0];
-          const structProperties = varName.split("props:")[1]?.trim();
+          const structMetadata = varName.split("props:")[1]?.trim();
+          const structProperties = structMetadata?.split(" types:")[0]?.trim();
+          const structTypeNames = structMetadata
+            ?.split(" types:")[1]
+            ?.trim()
+            ?.split(" ")
+            ?.filter(Boolean) || null;
           varName = varName.split("props:")[0]?.trim();
-          let isArray = false;
-          let isStruct = false;
-          if (varName.includes(" a")) {
-            isArray = true;
-          } 
-          if (varName.includes(" s")) {
-            isStruct = true;
+          const flags = varName.split(" ").slice(1);
+          const isArray = flags.includes("a");
+          const isStruct = flags.includes("s");
+          const isBytes20 = flags.includes("b20");
+          const isAddress = flags.includes("addr");
+          let commitmentType = null;
+          if (isBytes20) {
+            commitmentType = "bytes20";
+          } else if (isAddress) {
+            commitmentType = "address";
           }
           const plainText = decrypt(
             cipherText,
@@ -962,7 +982,7 @@ const prepareBackupDataRetriever = (node: any) => {
           if (isStruct){
             value = {};
             let count = isArray ? 3 : 2;
-            for (const prop of structProperties.split(" ")) {
+            for (const prop of structProperties?.split(" ").filter(Boolean) || []) {
               value[prop] = plainText[count];
               count++;
             }
@@ -1026,6 +1046,8 @@ const prepareBackupDataRetriever = (node: any) => {
             hash: newCommitment,
             name: name,
             mappingKey: mappingKey?.integer,
+            type: commitmentType,
+            typeNames: structTypeNames,
             preimage: {
               stateVarId: stateVarId,
               value: value,

--- a/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
@@ -272,6 +272,8 @@ export default function codeGenerator(node: any, options: any = {}): any {
         case 'address':
           if (options?.contractCall) return `${node.name}.hex(20)`
           return `${node.name}.integer`;
+        case 'bytes20':
+          return `${node.name}.integer`;
         case 'generalNumber':
           return `generalise(${node.name})`;
       }

--- a/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
@@ -66,7 +66,12 @@ export default function codeGenerator(node: any, options: any = {}): any {
       }
       if (!node.interactsWithSecret)
         return `\n// non-secret line would go here but has been filtered out`;
-      if (node.initialValue?.nodeType === 'Assignment') {
+      const isAssignment = node.initialValue?.nodeType === 'Assignment';
+      const isStructPropertyAssignment =
+        isAssignment &&
+        node.declarations[0].isStruct &&
+        node.initialValue.leftHandSide?.nodeType === 'MemberAccess';
+      if (isAssignment && !isStructPropertyAssignment) {
         if (node.declarations[0].isAccessed && node.declarations[0].isSecret) {
           let varName = node.initialValue.leftHandSide?.name ? node.initialValue.leftHandSide.name : node.declarations[0].name;
           return `${getAccessedValue(
@@ -79,6 +84,8 @@ export default function codeGenerator(node: any, options: any = {}): any {
         return `${getPublicValue(node.declarations[0])}`
       } else if (node.declarations[0].isAccessed) {
         return `${getAccessedValue(node.declarations[0].name)}`;
+      } else if (isStructPropertyAssignment) {
+        return `${getAccessedValue(node.declarations[0].name)}\n ${codeGenerator(node.initialValue)};`;
       }
       if (!node.initialValue && !node.declarations[0].isAccessed) return `\nlet ${codeGenerator(node.declarations[0])};`;
       if (node.initialValue &&

--- a/src/transformers/visitors/checks/unsupportedVisitor.ts
+++ b/src/transformers/visitors/checks/unsupportedVisitor.ts
@@ -10,6 +10,32 @@
 import { TODOError, ZKPError, ParseError } from '../../../error/errors.js';
 import { traverseNodesFast } from '../../../traverse/traverse.js';
 
+const disallowedVariableNames = new Set([
+  'key',
+  'secretKey',
+  'publicKey',
+  'sharedSecretKey',
+  'sharedPublicKey',
+  'keys',
+  'instance',
+  'contractAddr',
+  'web3',
+  'BackupData',
+  'msgSender',
+  'msgValue',
+  'allInputs',
+  'res',
+  'proof',
+  'txData',
+  'txParams',
+  'tx',
+  'signed',
+  'sendTxn',
+  'encEvent',
+  'encBackupEvent',
+  'publicReturns',
+]);
+
 
 export default {
   StructuredDocumentation: {
@@ -92,14 +118,16 @@ export default {
 
   VariableDeclaration: {
     enter(node: any) {
-      if (node.name.startsWith('_') && node.isSecret)
+      const variableName = node.name || '';
+
+      if (variableName.startsWith('_') && node.isSecret)
         throw new ZKPError(
           `Zokrates does not support variables that begin with an underscore such as as _value.`,
           node,
         );
-      if (node.name === 'key'){
+      if (disallowedVariableNames.has(variableName)) {
         throw new ZKPError(
-          `Zokrates does not support variables with the name key, please choose a different name.`,
+          `Zokrates does not support variables with the name ${variableName}, please choose a different name.`,
           node,
         );
       }

--- a/src/transformers/visitors/ownership/errorChecksVisitor.ts
+++ b/src/transformers/visitors/ownership/errorChecksVisitor.ts
@@ -38,7 +38,7 @@ export default {
           structDecl.members.forEach((member: any) => {
             const typeStr =
               member.typeName?.name || member.typeDescriptions?.typeString;
-            if (!typeStr || !['bool', 'uint256', 'address'].includes(typeStr)) {
+            if (!typeStr || !['bool', 'uint256', 'address', 'bytes20'].includes(typeStr)) {
               throw new TODOError(
                 `Secret struct with a property ${typeStr} that is not a supported type. See the Status documentation for more details`,
                 node,

--- a/src/transformers/visitors/toCircuitVisitor.ts
+++ b/src/transformers/visitors/toCircuitVisitor.ts
@@ -1185,7 +1185,7 @@ const visitor = {
     enter(path: NodePath) {
       const { node, parent } = path;
       if(!!path.getAncestorOfType('EventDefinition')) return;
-      const supportedTypes = ['uint256', 'address', 'bool'];
+      const supportedTypes = ['uint256', 'address', 'bool', 'bytes20'];
       if (!supportedTypes.includes(node.name))
         throw new Error(
           `Currently, only transpilation of types "${supportedTypes}" is supported. Got ${node.name} type.`,

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -672,8 +672,18 @@ const visitor = {
           if(indicators.isMapping) {
             for(const [name, mappingKey ] of Object.entries(indicators.mappingKeys)){ 
               if(mappingKey.encryptionRequired) {
+                if (mappingKey.isStruct)
                 mappingKey.isStruct ? 
-                file.nodes?.[0].stateVariables.push( {name: indicators.name, isMapping: true, mappingKey: name, isStruct: true, structProperty: Object.keys(mappingKey.structProperties), id: mappingKey.node.referencedDeclaration}) :
+                file.nodes?.[0].stateVariables.push( {
+                  name: indicators.name,
+                  isMapping: true,
+                  mappingKey: name,
+                  isStruct: true,
+                  structProperty:
+                    mappingKey.referencingPaths?.[0]?.getStructDeclaration()?.members.map((m: any) => m.name)
+                    || Object.keys(mappingKey.structProperties),
+                  id: mappingKey.node.referencedDeclaration
+                }) :
                 
                 file.nodes?.[0].stateVariables.push( {name: indicators.name, isMapping: true, mappingKey: name, id: mappingKey.node.referencedDeclaration});
             }

--- a/src/transformers/visitors/toOrchestrationVisitor.ts
+++ b/src/transformers/visitors/toOrchestrationVisitor.ts
@@ -612,6 +612,7 @@ const visitor = {
           isConstantArray?: boolean;
           isBool?: boolean;
           isAddress?: boolean;
+          isBytes20?: boolean;
         }
         let isReadOnly = false;
         if (node.stateMutability === 'view'){
@@ -627,7 +628,7 @@ const visitor = {
         });
         node.parameters.parameters.forEach((para: { isSecret: any; typeName: { name: string; }; name: any; _newASTPointer: { typeName: { properties: any[]; }; }; }) => {
           if (!para.isSecret) {
-            if (path.isStructDeclaration(para) || path.isConstantArray(para) || (para.typeName && para.typeName.name === 'bool') || (para.typeName && para.typeName.name === 'address')) {
+            if (path.isStructDeclaration(para) || path.isConstantArray(para) || (para.typeName && para.typeName.name === 'bool') || (para.typeName && para.typeName.name === 'address') || (para.typeName && para.typeName.name === 'bytes20')) {
               let newParam: PublicParam = { name: para.name };
               if (path.isStructDeclaration(para)) {
                 newParam.properties = para._newASTPointer.typeName.properties.map(p => ({ "name": p.name, "type": p.type }));
@@ -640,6 +641,9 @@ const visitor = {
               } 
               if (para.typeName?.name === 'address') {
                 newParam.isAddress = true;
+              }
+              if (para.typeName?.name === 'bytes20') {
+                newParam.isBytes20 = true;
               }
               sendPublicTransactionNode.publicInputs.push(newParam);
             } else {
@@ -1029,13 +1033,14 @@ const visitor = {
         // this adds other values we need in the tx
         for (const param of node.parameters.parameters) {
           if (!param.isSecret) {
-            if (path.isStructDeclaration(param) || path.isConstantArray(param)  ||( param.typeName && param.typeName.name === 'bool') || ( param.typeName && param.typeName.name === 'address')) {
+            if (path.isStructDeclaration(param) || path.isConstantArray(param)  ||( param.typeName && param.typeName.name === 'bool') || ( param.typeName && param.typeName.name === 'address') || ( param.typeName && param.typeName.name === 'bytes20')) {
               let newParam: any = {};
               newParam.name = param.name;
               if (path.isStructDeclaration(param)) newParam.properties = param._newASTPointer.typeName.properties.map(p => ({"name" : p.name, "type" : p.type }));
               if (path.isConstantArray(param)) newParam.isConstantArray = true;
               if (param.typeName?.name === 'bool') newParam.isBool = true;
               if (param.typeName?.name === 'address') newParam.isAddress = true;
+              if (param.typeName?.name === 'bytes20') newParam.isBytes20 = true;
               newNodes.sendTransactionNode.publicInputs.push(newParam);
             } else newNodes.sendTransactionNode.publicInputs.push(param.name);
           }

--- a/src/traverse/Scope.ts
+++ b/src/traverse/Scope.ts
@@ -427,7 +427,14 @@ export class Scope {
         ? indicator.structProperties[memberAccessNode.memberName]
         : indicator;
     }
-    if ((path.isConstantArray(referencingNode) || referencingNode.memberName === 'length') && !NodePath.getPath(referencingNode).getAncestorOfType('IndexAccess')) return indicator;
+    const referencingPath = NodePath.getPath(referencingNode);
+    const hasIndexAccessAncestor = referencingPath?.getAncestorOfType('IndexAccess');
+    if (
+      (path.isArray(referencingNode) ||
+        referencingNode.memberName === 'length') &&
+      !hasIndexAccessAncestor
+    )
+      return indicator;
     // getMappingKeyName requires an indexAccessNode - referencingNode may be a baseExpression or indexExpression contained Identifier
     const indexAccessNode =
       referencingNode.nodeType === 'IndexAccess'

--- a/test/contracts/action-tests/Bytes20.zol
+++ b/test/contracts/action-tests/Bytes20.zol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+contract Bytes20 {
+
+  secret bytes20 private secretWholeA;
+  secret bytes20 private secretWholeB;
+  bytes20 public publicWholeA;
+  bytes20 public publicWholeB;
+
+  secret bool isEqual;
+
+  secret mapping(uint256 => bytes20) private secretById;
+  mapping(uint256 => bytes20) public publicById;
+
+  secret mapping(bytes20 => uint256) private secretCountByKey;
+  mapping(bytes20 => uint256) public publicCountByKey;
+
+  struct RefRecord {
+    bytes20 ref;
+    uint256 tag;
+  }
+
+  secret RefRecord private secretRecord;
+  secret uint256 exampleTag;
+  RefRecord public publicRecord;
+  secret mapping(uint256 => RefRecord) private secretRecordById;
+  mapping(uint256 => RefRecord) public publicRecordById;
+
+  secret bytes20[] private secretRefs;
+  bytes20[] public publicRefs;
+  bytes20[4] public fixedPublicRefs;
+
+
+  function setWhole(
+    secret bytes20 newSecretA,
+    secret bytes20 newSecretB,
+    bytes20 newPublicA,
+    bytes20 newPublicB
+  ) public {
+    secretWholeA = newSecretA;
+    secretWholeB = newSecretB;
+    publicWholeA = newPublicA;
+    publicWholeB = newPublicB;
+    isEqual = secretWholeA == secretWholeB;
+  }
+
+
+  function setMapped(
+    secret uint256 secretId,
+    uint256 publicId,
+    secret bytes20 newSecretValue,
+    bytes20 newPublicValue
+  ) public {
+    secretById[secretId] = newSecretValue;
+    publicById[publicId] = newPublicValue;
+  }
+
+  function setByBytesKey(
+    secret bytes20 bytesKey,
+    bytes20 bytesKeyPublic,
+    secret uint256 secretCount,
+    uint256 publicCount
+  ) public {
+    secretCountByKey[bytesKey] = secretCount;
+    publicCountByKey[bytesKeyPublic] = publicCount;
+  }
+
+  function setStructData(
+    secret bytes20 secretRef,
+    bytes20 publicRef,
+    secret uint256 secretId,
+    uint256 publicId
+  ) public {
+    secretRecord.ref = secretRef;
+    secretRecord.tag += 1;
+
+    publicRecord.ref = publicRef;
+    publicRecord.tag += 1;
+
+    secretRecordById[secretId].ref = secretRef;
+    secretRecordById[secretId].tag += 1;
+
+    publicRecordById[publicId].ref = publicRef;
+    publicRecordById[publicId].tag += 1;
+  }
+
+  function setArrayData(
+    secret uint256 secretIndex,
+    secret bytes20 secretValue,
+    bytes20 publicValue
+  ) public {
+    secretRefs[secretIndex] = secretValue;
+    publicRefs.push(publicValue);
+    fixedPublicRefs[0] = publicValue;
+  }
+
+  function setViaLocal(secret bytes20 inputSecret, bytes20 inputPublic) public returns (bool) {
+    secret bytes20 localSecret = inputSecret;
+    bytes20 localPublic = inputPublic;
+    secretWholeA = localSecret;
+    publicWholeA = localPublic;
+    return true;
+  }
+
+  function equalsPublic(bytes20 expected) public view returns (bool) {
+    bool comparison = (publicWholeA == expected);
+    return comparison;
+  }
+}

--- a/test/contracts/action-tests/Escrow-refs.zol
+++ b/test/contracts/action-tests/Escrow-refs.zol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: CC0
+
+pragma solidity ^0.8.0;
+
+import "./Escrow-imports/IERC20.sol";
+
+contract Escrow {
+
+    secret mapping(address => uint256) public balances;
+    IERC20 public erc20;
+    secret bytes20[] public b;
+
+    struct TypeTest {
+        uint256 amount;
+        bytes20 amount2;
+        address amount3;
+        bool amount4;
+    }
+
+    sharedSecret mapping(address => bytes20) references;  
+
+    secret mapping(uint256 => TypeTest) private d;
+    secret bytes20 recentReference;
+    secret TypeTest refStruct;
+
+    constructor(address erc20Address) {
+        erc20 = IERC20(erc20Address);
+    }
+
+    function deposit(uint256 amount) public {
+        bool hasBalance = erc20.transferFrom(msg.sender, address(this), amount);
+        require(hasBalance == true);
+        balances[msg.sender] += amount;
+    }
+
+    function transfer(secret address recipient, secret uint256 amount, secret address sharedAddress, secret bytes20 transferRef) public {
+        require(recipient != address(0), "Escrow: transfer to the zero address");
+        balances[msg.sender] -= amount;
+        unknown balances[recipient] += amount;
+        references[sharedAddress] = transferRef;
+        recentReference = transferRef;
+        b[0] = transferRef;
+        refStruct.amount = 5;
+        refStruct.amount4 = true;
+        refStruct.amount3 = recipient;
+        refStruct.amount2 = transferRef;
+        d[0].amount = 5;
+        d[0].amount4 = true;
+        d[0].amount3 = recipient;
+        d[0].amount2 = transferRef;
+
+    }
+
+    function withdraw(uint256 amount) public {
+        bool success = erc20.transfer(msg.sender, amount);
+        require(success, "ERC20 transfer failed");
+        balances[msg.sender] -= amount;
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #441. This PR adds support for public and secret bytes20 variables into Starlight. It also includes several unrelated fixes:

## Changes

Bytes20 changes:

- Turn off unsupported errors for Bytes20.
- Stop using parseInt on bytes20 in orchestration as this leads to rounding errors. 
- Check bytes20 input to make sure they are in the correct format.
- In format commitments, treat bytes20 values as ascii or hex(20) depending on whether they are printable. Also treat addresses as hex(32) for better usability. 
- Ensure that public bytes20 variables are passed to the contract in orchestration in the correct format. 
- Update tests and documentation. 

Changes unrelated to bytes20:
- fixes a bug for mappings to structs. The order of parameters to proof generation in orchestration is defined by the order modified in the contract instead of the struct declaration. This means the order is not consistent with the circuit.
- creates an error message when variable names are used in zolidity contracts that could clash with names in orchestration. 
- fixes an error for structs in orchestration. If the first time a struct is modified it is an assignment, then the initial struct is set to {}, because it will be fully overwritten anyway. However, a property assignment was being treated in the same way and the initial struct set to {}, even though one property was being assigned, and so all other properties were incorrect. 
- Fix a zappify error when .push is used for a public array, the array was being treated as a mapping because we were checking isConstantArray instead of isArray.
- Fix an orchestration error when public bools are returned. We should filter out public variables from the returns from the orchestration file unless true or false is returned, because they are treated separately in publicReturns. However, boolean variables were not being filtered out, and so were being treated later as secret variables. This meant the commitment value was being returned causing an error. 

## Checklist
- [x] Tests added/updated
- [x] CI passes
- [x] No secrets/keys committed
- [x] Docs updated (if needed)
- [x] Backwards compatible (or noted breaking change)

## How to test
Test action-tests/Escrow-refs (specifically transfer) and action-tests/Bytes20. 

## Screenshots / Evidence (if applicable)
Escrow-refs:
<img width="1170" height="812" alt="Screenshot 2026-03-11 at 12 34 11" src="https://github.com/user-attachments/assets/ab02d58d-708f-4710-9a8b-d0ea76ed58d8" />

Bytes20:
<img width="1174" height="808" alt="Screenshot 2026-03-11 at 12 34 45" src="https://github.com/user-attachments/assets/b25123c1-6c12-40d8-8f35-673f1ead386b" />
<img width="1184" height="810" alt="Screenshot 2026-03-11 at 12 34 57" src="https://github.com/user-attachments/assets/e6db6e93-6ca9-4b77-bbbd-32b96c2aeb6a" />
<img width="1183" height="823" alt="Screenshot 2026-03-11 at 12 35 08" src="https://github.com/user-attachments/assets/3e67a1b3-3698-46f9-bf52-13aebc71b07d" />
<img width="1208" height="850" alt="Screenshot 2026-03-11 at 12 35 21" src="https://github.com/user-attachments/assets/be09bcee-d97b-4a9c-9396-c7c7c5a84b4e" />
<img width="1174" height="829" alt="Screenshot 2026-03-11 at 12 35 36" src="https://github.com/user-attachments/assets/f18bb57b-f7d1-44c0-8d22-8d07153e8ee8" />
<img width="1170" height="816" alt="Screenshot 2026-03-11 at 12 35 51" src="https://github.com/user-attachments/assets/c7b35637-e53f-48e9-b588-8861e369fbaa" />
<img width="1198" height="717" alt="Screenshot 2026-03-11 at 12 36 05" src="https://github.com/user-attachments/assets/4f9ba63c-900e-431c-a71d-f3caa9a69032" />


-