### PR TITLE
fix:incorrect operator precedence

### DIFF
--- a/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/nodejs/toOrchestration.ts
@@ -134,7 +134,10 @@ export default function codeGenerator(node: any, options: any = {}): any {
         }
         if (node.expression.operator === '-='){
           increments = codeGenerator(node.expression.rightHandSide);
-          return  `\n${privateStateName}_newCommitmentValue = generalise(parseInt(${privateStateName}_newCommitmentValue.integer, 10) + (${increments}));\n`;
+          const incrementsWithParens = node.expression.rightHandSide.nodeType === 'BinaryOperation' 
+            ? `(${increments})` 
+            : increments;
+          return  `\n${privateStateName}_newCommitmentValue = generalise(parseInt(${privateStateName}_newCommitmentValue.integer, 10) - (${incrementsWithParens}));\n`;
         }
         if (node.expression.operator === '='){
           increments = codeGenerator(node.expression.rightHandSide);
@@ -163,22 +166,30 @@ export default function codeGenerator(node: any, options: any = {}): any {
       // To ensure the left hand side is always a general number, we generalise it here (excluding the initialisation in a for loop).    
       if (!node.isInitializationAssignment && node.rightHandSide.subType !== 'generalNumber'){
         if (['+=', '-=', '*='].includes(node.operator)) {
+          const rightHandSideCode = codeGenerator(node.rightHandSide);
+          const rightHandSideWithParens = node.rightHandSide.nodeType === 'BinaryOperation' 
+            ? `(${rightHandSideCode})` 
+            : rightHandSideCode;
           return `${codeGenerator(node.leftHandSide, {
             lhs: true,
           })} = generalise(${codeGenerator(node.leftHandSide)} ${node.operator.charAt(
             0,
-          )} ${codeGenerator(node.rightHandSide)})`;
+          )} ${rightHandSideWithParens})`;
         }
          return `${codeGenerator(node.leftHandSide, { lhs: true })} ${
           node.operator
         } generalise(${codeGenerator(node.rightHandSide)})`;
       } else {
         if (['+=', '-=', '*='].includes(node.operator)) {
+          const rightHandSideCode = codeGenerator(node.rightHandSide);
+          const rightHandSideWithParens = node.rightHandSide.nodeType === 'BinaryOperation' 
+            ? `(${rightHandSideCode})` 
+            : rightHandSideCode;
           return `${codeGenerator(node.leftHandSide, {
             lhs: true,
           })} = ${codeGenerator(node.leftHandSide)} ${node.operator.charAt(
             0,
-          )} ${codeGenerator(node.rightHandSide)}`;
+          )} ${rightHandSideWithParens}`;
         }
         return `${codeGenerator(node.leftHandSide, { lhs: true })} ${
           node.operator


### PR DESCRIPTION
## Summary
Previously, there was an incorrect evaluation(a -= b + c --> a - b + c). the changes made wraps binary RHS in parentheses to return the desired output(a - (b + c)), matching Solidity behavior.

## Related Issues
https://github.com/EYBlockchain/starlight/issues/454

## Checklist
- [x] Tests added/updated(n/a)
- [ ] CI passes
- [x] No secrets/keys committed
- [x] Docs updated (if needed)
- [x] Backwards compatible (or noted breaking change)
