### PR TITLE
Lyd/unsupported pub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       # Runs a single command using the runners shell
       - name: compile and test
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '16.17.0'
 
@@ -76,4 +76,3 @@ jobs:
        
       - name: run zapp apitest
         run: npx mocha --exit --timeout 50000 --require @babel/register apitest.js
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: compile and test
         run: |
           npm i npm@7
-          tsc
+          npx tsc
           npm test
 
       - name: compile shield contracts and circuits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: '14.17.0'
       - run: |
           npm install
-          tsc
+          npx tsc
 
       - uses: codfish/semantic-release-action@master
         id: semantic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '14.17.0'
       - run: |

--- a/src/codeGenerators/orchestration/files/toOrchestration.ts
+++ b/src/codeGenerators/orchestration/files/toOrchestration.ts
@@ -543,7 +543,7 @@ const prepareMigrationsFile = (file: localFile, node: any) => {
         }
       }
     });
-  } else if(constructorParamsIncludesAddr) {
+  } else if (!node.isConstructor && constructorParamsIncludesAddr) {
     // for each address in the shield contract constructor...
     constructorAddrParams.forEach(name => {
       // we have an address input which is likely not a another contract
@@ -556,7 +556,7 @@ const prepareMigrationsFile = (file: localFile, node: any) => {
     });
   }
   if (node.isConstructor) {
-    // we have a constructor which requires a proof
+    // we have a cnstrctr.mjs file
     if (node.functionNames.includes('cnstrctr') || publicConstructorParams.length > 0) {
       customProofImport += `const constructorInput = JSON.parse(
         fs.readFileSync('/app/orchestration/common/db/constructorTx.json', 'utf-8'),

--- a/test/real-world-zapps/Voting.zol
+++ b/test/real-world-zapps/Voting.zol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 contract Voting {
 
     secret mapping (uint256 => uint256) public proposalVotes;
-    mapping (uint256 => bytes32) public proposals;
+    mapping (uint256 => bytes20) public proposals;
     mapping (address => bool) public hasVoted;
     mapping (address => bool) public canPropose;
     address public admin;
@@ -21,7 +21,7 @@ contract Voting {
       hasVoted[msg.sender] = true;
     }
 
-    function propose(uint256 proposalId, bytes32 proposalName) public {
+    function propose(uint256 proposalId, bytes20 proposalName) public {
         require(canPropose[msg.sender]);
         proposals[proposalId] = proposalName;
     }


### PR DESCRIPTION


## Summary
This PR fixes two bugs in test/real-world-zapps/Voting.zol:

-  Only a small subset of types are supported for secret variables. However, we should do the same for public variables that interact with secret ones, as discussed in https://github.com/EYBlockchain/starlight/issues/486. In Voting.zol although the bytes32 variables are public variables, they interact with secret ones and so we must use bytes20 which is supported.
- There is a bug in deployment due to two variables being created with the same name. This is because the constructor is input a public address _admin. The default address is automatically used for public addresses, and so _admin is set to that. However, because _admin is also input to the deployment via the cnstrctr.mjs file. 

## Related Issues
- https://github.com/EYBlockchain/starlight/issues/486
- https://github.com/EYBlockchain/starlight/issues/485


## Checklist
- [x] Tests added/updated
- [x] CI passes
- [x] No secrets/keys committed
- [x] Docs updated (if needed)
- [x] Backwards compatible (or noted breaking change)

## How to test
1. Test Voting.zol in real-world-zapps. 

## Screenshots / Evidence (if applicable)
<img width="1199" height="619" alt="Screenshot 2026-04-16 at 17 04 46" src="https://github.com/user-attachments/assets/d717b1c4-7362-4ca2-8615-4cb95497d204" />


<img width="1224" height="665" alt="Screenshot 2026-04-16 at 17 15 48" src="https://github.com/user-attachments/assets/025e84e4-d6f4-43f3-83e7-a3fb1e0e2fd9" />

<img width="1184" height="451" alt="Screenshot 2026-04-16 at 17 09 27" src="https://github.com/user-attachments/assets/2bf08d09-3785-4b18-b663-ca462696a0f6" />


