### PR TITLE
Lyd/ignore sent commitments

### DIFF
--- a/apitest.js
+++ b/apitest.js
@@ -899,7 +899,7 @@ describe('BucketsOfBalls Zapp', () => {
     ).to.equal(8);
   });
   it('Check commitments are correct after deleting and restoring from backup', async () => {
-    expect(res.BucketsOfBalls[7].body.commitments.length).to.equal(3);
+    expect(res.BucketsOfBalls[7].body.commitments.length).to.equal(4);
     expectNewLeavesEvent(res.BucketsOfBalls[8].body);
   });
   it('Test getBalanceByState', async () => {

--- a/src/boilerplate/common/commitment-storage.mjs
+++ b/src/boilerplate/common/commitment-storage.mjs
@@ -24,6 +24,45 @@ const keyDb =
 const PRINTABLE_ASCII_REGEX = /^[\x20-\x7E]*$/;
 const NULLIFIER_EVENTS_COLLECTION = `${COMMITMENTS_COLLECTION}_nullifiers`;
 
+function normalisePublicKey(publicKey) {
+  if (publicKey === null || publicKey === undefined || publicKey === '')
+    return null;
+  const normalised = generalise(publicKey);
+  if (normalised.bigInt === 0n) return null;
+  return normalised.hex(32);
+}
+
+function normalisePublicKeys(publicKeys) {
+  const values = Array.isArray(publicKeys) ? publicKeys : [publicKeys];
+  return Array.from(
+    new Set(values.map(normalisePublicKey).filter(publicKey => publicKey)),
+  );
+}
+
+function getLocalPublicKeys() {
+  if (!fs.existsSync(keyDb)) {
+    throw new Error(
+      `Cannot determine owned commitments: key DB not found at ${keyDb}`,
+    );
+  }
+  const keys = JSON.parse(
+    fs.readFileSync(keyDb, 'utf-8', err => {
+      console.log(err);
+    }),
+  );
+  return normalisePublicKeys([keys.publicKey, keys.sharedPublicKey]);
+}
+
+function ownedCommitmentQuery() {
+  const ownedPublicKeys = getLocalPublicKeys();
+  return {
+    'preimage.publicKey':
+      ownedPublicKeys.length === 1
+        ? ownedPublicKeys[0]
+        : { $in: ownedPublicKeys },
+  };
+}
+
 async function getCommitmentsDb() {
   const connection = await mongo.connection(MONGO_URL);
   return connection.db(COMMITMENTS_DB);
@@ -241,6 +280,7 @@ export async function getCurrentWholeCommitment(id) {
   const commitment = await commitmentsCollection.findOne({
     'preimage.stateVarId': generalise(id).hex(32),
     isNullified: false,
+    ...ownedCommitmentQuery(),
   });
   return commitment;
 }
@@ -283,7 +323,10 @@ export async function getNullifiedCommitments() {
 export async function getBalance() {
   const commitmentsCollection = await getCommitmentsCollection();
   const commitments = await commitmentsCollection
-    .find({ isNullified: false }) //  no nullified
+    .find({
+      isNullified: false,
+      ...ownedCommitmentQuery(),
+    }) //  no nullified
     .toArray();
 
   let sumOfValues = 0;
@@ -295,16 +338,18 @@ export async function getBalance() {
 
 export async function getBalanceByState(name, mappingKey = null) {
   const commitmentsCollection = await getCommitmentsCollection();
-  const query = { name: name };
+  const query = {
+    name,
+    isNullified: false,
+    ...ownedCommitmentQuery(),
+  };
   if (mappingKey) query['mappingKey'] = generalise(mappingKey).integer;
   const commitments = await commitmentsCollection
     .find(query)
     .toArray();
   let sumOfValues = 0;
   commitments.forEach(commitment => {
-    sumOfValues += commitment.isNullified
-      ? 0
-      : parseInt(commitment.preimage.value, 10);
+    sumOfValues += parseInt(commitment.preimage.value, 10);
   });
   return sumOfValues;
 }

--- a/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
+++ b/src/boilerplate/orchestration/javascript/raw/toOrchestration.ts
@@ -125,6 +125,12 @@ function transformToIntegerAccess(para: string): string {
   }
 };
 
+const publicKeyLookupWithFallback = (stateName: string, addressExpression: string) => `_${stateName}_newOwnerPublicKey === 0 ? generalise(await instance.methods.zkpPublicKeys(${addressExpression}).call()) : ${stateName}_newOwnerPublicKey;
+            \nif (${stateName}_newOwnerPublicKey.bigInt === 0n) {
+              console.log('WARNING: Public key not found on chain - using your public key');
+              ${stateName}_newOwnerPublicKey = publicKey;
+            }`;
+
 export const generateProofBoilerplate = (node: any) => {
   const output: (string[] | string)[] = [];
   const enc: any[][] = [];
@@ -347,19 +353,14 @@ export const preimageBoilerPlate = (node: any) => {
           newOwnerStatment = `publicKey;`;
         } else if (stateNode.mappingOwnershipType === 'key') {
           // the stateVarId[1] is the mapping key
-          newOwnerStatment = `generalise(await instance.methods.zkpPublicKeys(${stateNode.stateVarId[1]}.hex(20)).call()); // address should be registered`;
+          newOwnerStatment = publicKeyLookupWithFallback(privateStateName, `${stateNode.stateVarId[1]}.hex(20)`);
         } else if (stateNode.mappingOwnershipType === 'value') {
           if (stateNode.reinitialisable){
             newOwnerStatment = `_${privateStateName}_newOwnerPublicKey === 0 ? publicKey : ${privateStateName}_newOwnerPublicKey;`;
           } else {
             // TODO test below
             // if the private state is an address (as here) its still in eth form - we need to convert
-            newOwnerStatment = `await instance.methods.zkpPublicKeys(${privateStateName}.hex(20)).call();
-            \nif (${privateStateName}_newOwnerPublicKey === 0) {
-              console.log('WARNING: Public key for given eth address not found - reverting to your public key');
-              ${privateStateName}_newOwnerPublicKey = publicKey;
-            }
-            \n${privateStateName}_newOwnerPublicKey = generalise(${privateStateName}_newOwnerPublicKey);`;
+            newOwnerStatment = publicKeyLookupWithFallback(privateStateName, `${privateStateName}.hex(20)`);
           }
         } else {
           if(stateNode.isSharedSecret)
@@ -374,7 +375,7 @@ export const preimageBoilerPlate = (node: any) => {
         if (stateNode.isSharedSecret) {
           newOwnerStatment = `_${privateStateName}_newOwnerPublicKey === 0 ? sharedPublicKey : ${privateStateName}_newOwnerPublicKey;`;
         } else if (!stateNode.ownerIsSecret && !stateNode.ownerIsParam) {
-          newOwnerStatment = `_${privateStateName}_newOwnerPublicKey === 0 ? generalise(await instance.methods.zkpPublicKeys(await instance.methods.${newOwner}().call()).call()) : ${privateStateName}_newOwnerPublicKey;`;
+          newOwnerStatment = publicKeyLookupWithFallback(privateStateName, `await instance.methods.${newOwner}().call()`);
         } else if (stateNode.ownerIsParam && newOwner) {
           newOwnerStatment = `_${privateStateName}_newOwnerPublicKey === 0 ? ${newOwner} : ${privateStateName}_newOwnerPublicKey;`;
         } else {


### PR DESCRIPTION
## Summary
In the commitment DB in Starlight, we store commitments that are created on behalf of another user. However, if it is a whole variable this could cause a problem if the ownership of that variable is later transferred back to us. Consider the contract NFT_Escrow.zol, lets say we transfer a token to another user, and they then transfer it back to us. We will save the commitment during the initial transfer that we are sending to another user. We then receive another commitment with the same state id. However, because the first commitment is owned by the other user, we will never learn that it has been nullified as we do not own the variable and so don't know the nullifier. Therefore, if we try to use the token sent to us, we will use the first commitment instead of the second which causes an error. 

## Changes

- When we call getCommitmentsDb, getBalance and getBalanceByState we filter commitments so that the public key is either the default one or the shared public key. 

- Previously, in contracts like BucketsOfBalls.zol where the ownership is a public address, we obtain the public key for new commitments by checking the on-chain mapping, even if this has not been set. If this is the case the public key used will be 0, which will mean that it will be filter out as per the previous change. As is already the case for secret addresses, we should default to the optional public key chosen by the user in the API call, then use the on-chain mapping if it exists, and otherwise use the default public key. 

## Checklist
- [x] Tests added/updated
- [x] CI passes
- [x] No secrets/keys committed
- [x] Docs updated (if needed)
- [x] Backwards compatible (or noted breaking change)

## How to test
1. Test the Swap.zol contract with ./bin/startup-double. First complete a swap, and then complete a swap again reversing the tokens back to the original owners.

